### PR TITLE
feat: add patent service with attachment support

### DIFF
--- a/backend/src/main/java/com/patentsight/patent/dto/PatentRequest.java
+++ b/backend/src/main/java/com/patentsight/patent/dto/PatentRequest.java
@@ -1,0 +1,12 @@
+package com.patentsight.patent.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PatentRequest {
+    private String title;
+    private String type;
+    private List<Long> fileIds;
+}

--- a/backend/src/main/java/com/patentsight/patent/dto/PatentResponse.java
+++ b/backend/src/main/java/com/patentsight/patent/dto/PatentResponse.java
@@ -1,0 +1,13 @@
+package com.patentsight.patent.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PatentResponse {
+    private Long patentId;
+    private String title;
+    private String type;
+    private List<Long> attachmentIds;
+}

--- a/backend/src/main/java/com/patentsight/patent/model/FileAttachment.java
+++ b/backend/src/main/java/com/patentsight/patent/model/FileAttachment.java
@@ -1,0 +1,20 @@
+package com.patentsight.patent.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "file_attachments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Additional fields can be added as necessary
+}

--- a/backend/src/main/java/com/patentsight/patent/model/Patent.java
+++ b/backend/src/main/java/com/patentsight/patent/model/Patent.java
@@ -1,0 +1,36 @@
+package com.patentsight.patent.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "patents")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Patent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long patentId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String type;
+
+    @ManyToMany
+    @JoinTable(
+            name = "patent_attachments",
+            joinColumns = @JoinColumn(name = "patent_id"),
+            inverseJoinColumns = @JoinColumn(name = "attachment_id")
+    )
+    @Builder.Default
+    private Set<FileAttachment> attachments = new HashSet<>();
+}

--- a/backend/src/main/java/com/patentsight/patent/repository/FileAttachmentRepository.java
+++ b/backend/src/main/java/com/patentsight/patent/repository/FileAttachmentRepository.java
@@ -1,0 +1,7 @@
+package com.patentsight.patent.repository;
+
+import com.patentsight.patent.model.FileAttachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileAttachmentRepository extends JpaRepository<FileAttachment, Long> {
+}

--- a/backend/src/main/java/com/patentsight/patent/repository/PatentRepository.java
+++ b/backend/src/main/java/com/patentsight/patent/repository/PatentRepository.java
@@ -1,0 +1,7 @@
+package com.patentsight.patent.repository;
+
+import com.patentsight.patent.model.Patent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PatentRepository extends JpaRepository<Patent, Long> {
+}

--- a/backend/src/main/java/com/patentsight/patent/service/PatentService.java
+++ b/backend/src/main/java/com/patentsight/patent/service/PatentService.java
@@ -1,0 +1,49 @@
+package com.patentsight.patent.service;
+
+import com.patentsight.patent.dto.PatentRequest;
+import com.patentsight.patent.dto.PatentResponse;
+import com.patentsight.patent.model.FileAttachment;
+import com.patentsight.patent.model.Patent;
+import com.patentsight.patent.repository.FileAttachmentRepository;
+import com.patentsight.patent.repository.PatentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class PatentService {
+
+    private final PatentRepository patentRepository;
+    private final FileAttachmentRepository fileAttachmentRepository;
+
+    public PatentService(PatentRepository patentRepository,
+                         FileAttachmentRepository fileAttachmentRepository) {
+        this.patentRepository = patentRepository;
+        this.fileAttachmentRepository = fileAttachmentRepository;
+    }
+
+    public PatentResponse createPatent(PatentRequest request) {
+        Patent patent = new Patent();
+        patent.setTitle(request.getTitle());
+        patent.setType(request.getType());
+
+        if (request.getFileIds() != null && !request.getFileIds().isEmpty()) {
+            List<FileAttachment> attachments = fileAttachmentRepository.findAllById(request.getFileIds());
+            patent.setAttachments(new HashSet<>(attachments));
+        }
+
+        Patent saved = patentRepository.save(patent);
+
+        PatentResponse response = new PatentResponse();
+        response.setPatentId(saved.getPatentId());
+        response.setTitle(saved.getTitle());
+        response.setType(saved.getType());
+        List<Long> attachmentIds = saved.getAttachments().stream()
+                .map(FileAttachment::getId)
+                .collect(Collectors.toList());
+        response.setAttachmentIds(attachmentIds);
+        return response;
+    }
+}


### PR DESCRIPTION
## Summary
- implement Patent entity and FileAttachment with repositories
- add DTOs and service logic to persist patents and attachments

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689019ca65548320999a46a7882ae070