### PR TITLE
feat: add file attachment CRUD service

### DIFF
--- a/backend/src/main/java/com/patentsight/file/controller/FileController.java
+++ b/backend/src/main/java/com/patentsight/file/controller/FileController.java
@@ -1,0 +1,58 @@
+package com.patentsight.file.controller;
+
+import com.patentsight.config.JwtTokenProvider;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.service.FileService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileController {
+
+    private final FileService fileService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public FileController(FileService fileService, JwtTokenProvider jwtTokenProvider) {
+        this.fileService = fileService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @PostMapping
+    public ResponseEntity<FileResponse> upload(@RequestParam("file") MultipartFile file,
+                                               @RequestHeader("Authorization") String authorization) {
+        Long userId = jwtTokenProvider.getUserIdFromHeader(authorization);
+        FileResponse res = fileService.create(file, userId);
+        return ResponseEntity.ok(res);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<FileResponse> get(@PathVariable("id") Long id) {
+        FileResponse res = fileService.get(id);
+        if (res == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(res);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<FileResponse> update(@PathVariable("id") Long id,
+                                               @RequestParam("file") MultipartFile file) {
+        FileResponse res = fileService.update(id, file);
+        if (res == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(res);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
+        boolean deleted = fileService.delete(id);
+        if (deleted) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
+    }
+}
+

--- a/backend/src/main/java/com/patentsight/file/domain/FileAttachment.java
+++ b/backend/src/main/java/com/patentsight/file/domain/FileAttachment.java
@@ -18,6 +18,20 @@ public class FileAttachment {
     private Long uploaderId;
 
     /**
+     * Original name of the uploaded file. Used for download/display
+     * purposes only and is not guaranteed to be unique.
+     */
+    private String fileName;
+
+    /**
+     * Location of the stored file. When running in production this will
+     * typically be an S3 URL or object key. For local development we
+     * persist files to the local file system and keep the relative path
+     * here so the client can retrieve the file directly.
+     */
+    private String fileUrl;
+
+    /**
      * All patent documents are stored as raw JSON text rather than as binary
      * files on disk. The content column keeps the latest text for the
      * attachment and is versioned separately through {@link SpecVersion}.
@@ -34,6 +48,10 @@ public class FileAttachment {
     public void setPatent(Patent patent) { this.patent = patent; }
     public Long getUploaderId() { return uploaderId; }
     public void setUploaderId(Long uploaderId) { this.uploaderId = uploaderId; }
+    public String getFileName() { return fileName; }
+    public void setFileName(String fileName) { this.fileName = fileName; }
+    public String getFileUrl() { return fileUrl; }
+    public void setFileUrl(String fileUrl) { this.fileUrl = fileUrl; }
     public String getContent() { return content; }
     public void setContent(String content) { this.content = content; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }

--- a/backend/src/main/java/com/patentsight/file/dto/FileResponse.java
+++ b/backend/src/main/java/com/patentsight/file/dto/FileResponse.java
@@ -1,4 +1,73 @@
 package com.patentsight.file.dto;
 
+import java.time.LocalDateTime;
+
+/**
+ * Generic file metadata returned when creating or requesting a
+ * {@link com.patentsight.file.domain.FileAttachment}.
+ */
 public class FileResponse {
+    private Long fileId;
+    private Long patentId;
+    private Long uploaderId;
+    private String fileName;
+    private String fileUrl;
+    private String content;
+    private LocalDateTime updatedAt;
+
+    public Long getFileId() {
+        return fileId;
+    }
+
+    public void setFileId(Long fileId) {
+        this.fileId = fileId;
+    }
+
+    public Long getPatentId() {
+        return patentId;
+    }
+
+    public void setPatentId(Long patentId) {
+        this.patentId = patentId;
+    }
+
+    public Long getUploaderId() {
+        return uploaderId;
+    }
+
+    public void setUploaderId(Long uploaderId) {
+        this.uploaderId = uploaderId;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFileUrl() {
+        return fileUrl;
+    }
+
+    public void setFileUrl(String fileUrl) {
+        this.fileUrl = fileUrl;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
 }

--- a/backend/src/main/java/com/patentsight/file/service/FileService.java
+++ b/backend/src/main/java/com/patentsight/file/service/FileService.java
@@ -1,4 +1,88 @@
 package com.patentsight.file.service;
 
+import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.repository.FileRepository;
+import com.patentsight.global.util.FileUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
 public class FileService {
+
+    private final FileRepository fileRepository;
+
+    public FileService(FileRepository fileRepository) {
+        this.fileRepository = fileRepository;
+    }
+
+    /**
+     * Stores the given file on disk (or S3 in production) and returns the
+     * metadata for the created {@link FileAttachment}.
+     */
+    public FileResponse create(MultipartFile file, Long uploaderId) {
+        try {
+            String path = FileUtil.saveFile(file);
+            FileAttachment attachment = new FileAttachment();
+            attachment.setUploaderId(uploaderId);
+            attachment.setFileName(file.getOriginalFilename());
+            attachment.setFileUrl(path);
+            attachment.setUpdatedAt(LocalDateTime.now());
+            fileRepository.save(attachment);
+            return toResponse(attachment);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not store file", e);
+        }
+    }
+
+    public FileResponse get(Long id) {
+        return fileRepository.findById(id).map(this::toResponse).orElse(null);
+    }
+
+    /**
+     * Replaces the physical file and updates metadata.
+     */
+    public FileResponse update(Long id, MultipartFile file) {
+        FileAttachment attachment = fileRepository.findById(id).orElse(null);
+        if (attachment == null) return null;
+        try {
+            FileUtil.deleteFile(attachment.getFileUrl());
+            String path = FileUtil.saveFile(file);
+            attachment.setFileName(file.getOriginalFilename());
+            attachment.setFileUrl(path);
+            attachment.setUpdatedAt(LocalDateTime.now());
+            fileRepository.save(attachment);
+            return toResponse(attachment);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not update file", e);
+        }
+    }
+
+    public boolean delete(Long id) {
+        FileAttachment attachment = fileRepository.findById(id).orElse(null);
+        if (attachment == null) return false;
+        try {
+            FileUtil.deleteFile(attachment.getFileUrl());
+        } catch (IOException ignored) {
+        }
+        fileRepository.delete(attachment);
+        return true;
+    }
+
+    private FileResponse toResponse(FileAttachment attachment) {
+        FileResponse res = new FileResponse();
+        res.setFileId(attachment.getFileId());
+        res.setPatentId(attachment.getPatent() != null ? attachment.getPatent().getPatentId() : null);
+        res.setUploaderId(attachment.getUploaderId());
+        res.setFileName(attachment.getFileName());
+        res.setFileUrl(attachment.getFileUrl());
+        res.setContent(attachment.getContent());
+        res.setUpdatedAt(attachment.getUpdatedAt());
+        return res;
+    }
 }

--- a/backend/src/main/java/com/patentsight/global/util/FileUtil.java
+++ b/backend/src/main/java/com/patentsight/global/util/FileUtil.java
@@ -1,4 +1,46 @@
 package com.patentsight.global.util;
 
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+/**
+ * Utility helpers for storing uploaded files. The implementation keeps files
+ * on the local file system under the {@code uploads} directory which makes it
+ * easy to run the application locally. In production the returned path can be
+ * used as an S3 object key after swapping the implementation.
+ */
 public class FileUtil {
+
+    private static final Path BASE_DIR = Path.of("uploads");
+
+    /**
+     * Saves the provided multipart file to disk and returns the absolute
+     * path. Directories are created as necessary.
+     */
+    public static String saveFile(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IOException("No file provided");
+        }
+        Files.createDirectories(BASE_DIR);
+        String filename = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        Path target = BASE_DIR.resolve(filename).toAbsolutePath();
+        Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+        return target.toString();
+    }
+
+    /**
+     * Removes the file at the given path if it exists. This is used when a
+     * {@link com.patentsight.file.domain.FileAttachment} is deleted or
+     * replaced.
+     */
+    public static void deleteFile(String path) throws IOException {
+        if (path != null) {
+            Files.deleteIfExists(Path.of(path));
+        }
+    }
 }

--- a/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
+++ b/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
@@ -1,0 +1,57 @@
+package com.patentsight.file.service;
+
+import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.repository.FileRepository;
+import com.patentsight.global.util.FileUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+    @Mock
+    private FileRepository fileRepository;
+
+    @InjectMocks
+    private FileService fileService;
+
+    @BeforeEach
+    void setup() {
+        fileService = new FileService(fileRepository);
+    }
+
+    @Test
+    void createStoresFileAndReturnsMetadata() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "hello.txt", "text/plain", "hello".getBytes());
+
+        when(fileRepository.save(any(FileAttachment.class))).thenAnswer(invocation -> {
+            FileAttachment att = invocation.getArgument(0);
+            att.setFileId(1L);
+            return att;
+        });
+
+        FileResponse res = fileService.create(multipartFile, 99L);
+
+        assertNotNull(res);
+        assertEquals(1L, res.getFileId());
+        assertEquals(99L, res.getUploaderId());
+        assertEquals("hello.txt", res.getFileName());
+        assertNotNull(res.getFileUrl());
+        verify(fileRepository).save(any(FileAttachment.class));
+
+        // cleanup saved file
+        FileUtil.deleteFile(res.getFileUrl());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FileAttachment fields to track name and storage URL
- implement FileService, FileController and FileResponse for file CRUD
- support local file storage via FileUtil and add unit test

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6893f7184e808320ab51218173f6c365