### PR TITLE
Add CRUD endpoints for 3D model generation and persistence

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/controller/AiImageController.java
+++ b/backend/src/main/java/com/patentsight/ai/controller/AiImageController.java
@@ -30,4 +30,16 @@ public class AiImageController {
         Generated3DModelResponse response = aiImageService.generate3DModel(request);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/3d-models/{id}")
+    public ResponseEntity<Generated3DModelResponse> get3DModel(@PathVariable Long id) {
+        Generated3DModelResponse response = aiImageService.getGenerated3DModel(id);
+        return response != null ? ResponseEntity.ok(response) : ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/3d-models/{id}")
+    public ResponseEntity<Void> delete3DModel(@PathVariable Long id) {
+        boolean deleted = aiImageService.deleteGenerated3DModel(id);
+        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
 }

--- a/backend/src/main/java/com/patentsight/ai/domain/Generated3DModel.java
+++ b/backend/src/main/java/com/patentsight/ai/domain/Generated3DModel.java
@@ -1,0 +1,54 @@
+package com.patentsight.ai.domain;
+
+import com.patentsight.file.domain.FileAttachment;
+import jakarta.persistence.*;
+
+@Entity
+public class Generated3DModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String resultId;
+
+    @ManyToOne
+    @JoinColumn(name = "generated_file_id")
+    private FileAttachment generatedFile;
+
+    @ManyToOne
+    @JoinColumn(name = "source_file_id")
+    private FileAttachment sourceFile;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getResultId() {
+        return resultId;
+    }
+
+    public void setResultId(String resultId) {
+        this.resultId = resultId;
+    }
+
+    public FileAttachment getGeneratedFile() {
+        return generatedFile;
+    }
+
+    public void setGeneratedFile(FileAttachment generatedFile) {
+        this.generatedFile = generatedFile;
+    }
+
+    public FileAttachment getSourceFile() {
+        return sourceFile;
+    }
+
+    public void setSourceFile(FileAttachment sourceFile) {
+        this.sourceFile = sourceFile;
+    }
+}

--- a/backend/src/main/java/com/patentsight/ai/dto/Generated3DModelResponse.java
+++ b/backend/src/main/java/com/patentsight/ai/dto/Generated3DModelResponse.java
@@ -1,12 +1,24 @@
 package com.patentsight.ai.dto;
 
 public class Generated3DModelResponse {
+    private Long id;
     private String resultId;
-    private String filePath;
+    private Long fileId;
+    private String fileUrl;
 
-    public Generated3DModelResponse(String resultId, String filePath) {
+    public Generated3DModelResponse(Long id, String resultId, Long fileId, String fileUrl) {
+        this.id = id;
         this.resultId = resultId;
-        this.filePath = filePath;
+        this.fileId = fileId;
+        this.fileUrl = fileUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public String getResultId() {
@@ -17,11 +29,19 @@ public class Generated3DModelResponse {
         this.resultId = resultId;
     }
 
-    public String getFilePath() {
-        return filePath;
+    public Long getFileId() {
+        return fileId;
     }
 
-    public void setFilePath(String filePath) {
-        this.filePath = filePath;
+    public void setFileId(Long fileId) {
+        this.fileId = fileId;
+    }
+
+    public String getFileUrl() {
+        return fileUrl;
+    }
+
+    public void setFileUrl(String fileUrl) {
+        this.fileUrl = fileUrl;
     }
 }

--- a/backend/src/main/java/com/patentsight/ai/dto/ImageIdRequest.java
+++ b/backend/src/main/java/com/patentsight/ai/dto/ImageIdRequest.java
@@ -2,7 +2,7 @@ package com.patentsight.ai.dto;
 
 public class ImageIdRequest {
     private Long patentId;
-    private String imageId;
+    private Long imageId;
 
     public Long getPatentId() {
         return patentId;
@@ -12,11 +12,11 @@ public class ImageIdRequest {
         this.patentId = patentId;
     }
 
-    public String getImageId() {
+    public Long getImageId() {
         return imageId;
     }
 
-    public void setImageId(String imageId) {
+    public void setImageId(Long imageId) {
         this.imageId = imageId;
     }
 }

--- a/backend/src/main/java/com/patentsight/ai/repository/Generated3DModelRepository.java
+++ b/backend/src/main/java/com/patentsight/ai/repository/Generated3DModelRepository.java
@@ -1,0 +1,7 @@
+package com.patentsight.ai.repository;
+
+import com.patentsight.ai.domain.Generated3DModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface Generated3DModelRepository extends JpaRepository<Generated3DModel, Long> {
+}

--- a/backend/src/main/java/com/patentsight/ai/service/AiImageService.java
+++ b/backend/src/main/java/com/patentsight/ai/service/AiImageService.java
@@ -12,4 +12,8 @@ public interface AiImageService {
     List<ImageSimilarityResponse> analyzeImageSimilarity(ImageSimilarityRequest request);
 
     Generated3DModelResponse generate3DModel(ImageIdRequest request);
+
+    Generated3DModelResponse getGenerated3DModel(Long id);
+
+    boolean deleteGenerated3DModel(Long id);
 }

--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
@@ -1,22 +1,40 @@
 package com.patentsight.ai.service.impl;
 
 import com.patentsight.ai.client.ThreeDModelApiClient;
+import com.patentsight.ai.domain.Generated3DModel;
 import com.patentsight.ai.dto.*;
+import com.patentsight.ai.repository.Generated3DModelRepository;
 import com.patentsight.ai.service.AiImageService;
+import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.repository.FileRepository;
+import com.patentsight.file.service.FileService;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 public class AiImageServiceImpl implements AiImageService {
 
     private final ThreeDModelApiClient threeDModelApiClient;
+    private final FileService fileService;
+    private final FileRepository fileRepository;
+    private final Generated3DModelRepository generated3DModelRepository;
 
-    public AiImageServiceImpl(ThreeDModelApiClient threeDModelApiClient) {
+    public AiImageServiceImpl(ThreeDModelApiClient threeDModelApiClient,
+                              FileService fileService,
+                              FileRepository fileRepository,
+                              Generated3DModelRepository generated3DModelRepository) {
         this.threeDModelApiClient = threeDModelApiClient;
+        this.fileService = fileService;
+        this.fileRepository = fileRepository;
+        this.generated3DModelRepository = generated3DModelRepository;
     }
 
     @Override
@@ -28,9 +46,59 @@ public class AiImageServiceImpl implements AiImageService {
 
     @Override
     public Generated3DModelResponse generate3DModel(ImageIdRequest request) {
-        Mono<Generate3DModelApiResponse> mono = threeDModelApiClient.generate(
-                Paths.get("uploads", request.getImageId() + ".jpg"));
+        Long fileId = request.getImageId();
+        FileResponse fileResponse = fileService.get(fileId);
+        if (fileResponse == null) {
+            throw new IllegalArgumentException("File not found");
+        }
+        Path path = Paths.get(fileResponse.getFileUrl());
+        Mono<Generate3DModelApiResponse> mono = threeDModelApiClient.generate(path);
         Generate3DModelApiResponse apiResponse = mono.block();
-        return new Generated3DModelResponse(apiResponse.getResultId(), apiResponse.getFilePath());
+
+        FileAttachment attachment = fileRepository.findById(fileId)
+                .orElseThrow(() -> new IllegalArgumentException("File not found"));
+
+        FileAttachment generatedAttachment = new FileAttachment();
+        generatedAttachment.setUploaderId(attachment.getUploaderId());
+        generatedAttachment.setFileName(Paths.get(apiResponse.getFilePath()).getFileName().toString());
+        generatedAttachment.setFileUrl(apiResponse.getFilePath());
+        generatedAttachment.setUpdatedAt(LocalDateTime.now());
+        generatedAttachment.setPatent(attachment.getPatent());
+        fileRepository.save(generatedAttachment);
+
+        Generated3DModel model = new Generated3DModel();
+        model.setResultId(apiResponse.getResultId());
+        model.setGeneratedFile(generatedAttachment);
+        model.setSourceFile(attachment);
+        generated3DModelRepository.save(model);
+
+        return new Generated3DModelResponse(model.getId(), model.getResultId(),
+                generatedAttachment.getFileId(), generatedAttachment.getFileUrl());
+    }
+
+    @Override
+    public Generated3DModelResponse getGenerated3DModel(Long id) {
+        Optional<Generated3DModel> model = generated3DModelRepository.findById(id);
+        return model.map(m -> new Generated3DModelResponse(
+                m.getId(),
+                m.getResultId(),
+                m.getGeneratedFile().getFileId(),
+                m.getGeneratedFile().getFileUrl()))
+                .orElse(null);
+    }
+
+    @Override
+    public boolean deleteGenerated3DModel(Long id) {
+        Optional<Generated3DModel> modelOpt = generated3DModelRepository.findById(id);
+        if (modelOpt.isEmpty()) {
+            return false;
+        }
+        Generated3DModel model = modelOpt.get();
+        FileAttachment generated = model.getGeneratedFile();
+        if (generated != null) {
+            fileService.delete(generated.getFileId());
+        }
+        generated3DModelRepository.delete(model);
+        return true;
     }
 }

--- a/docs/patent-api.md
+++ b/docs/patent-api.md
@@ -69,7 +69,9 @@
 | Delete Drafts | 생성된 초안 삭제 | DELETE | /api/ai/drafts?patentId={patentId} | – | – |  |
 | Validate Patent Document | 출원 문서 오류 점검 (Rule + GPT) | POST | /api/ai/validations | `{"patentId":1}` | `[{"errorType":"MISSING_FIELD","message":"title is required"}]` | 규칙 기반 + AI 분석 |
 | Analyze Image Similarity | 이미지 유사도 분석 | POST | /api/ai/image-similarities | `{"patentId":1,"imageIds":[1,2]}` | `[{"imageId":1,"similarityScore":0.87}]` | 다중 이미지 가능 |
-| Generate 3D Model | 3D 모델 생성 | POST | /api/ai/3d-models | `{"patentId":1,"imageId":1}` | `{"resultId":1,"filePath":"/models/1.glb"}` | 외부 3D 생성 API 호출 (기본값: octree_resolution=256, num_inference_steps=8, guidance_scale=5.0, face_count=40000, texture=false)<br>결과는 FileAttachment로 연결 가능 |
+| Generate 3D Model | 3D 모델 생성 | POST | /api/ai/3d-models | `{"patentId":1,"imageId":1}` | `{"id":1,"resultId":"res-1","fileId":101,"fileUrl":"/models/1.glb"}` | 외부 3D 생성 API 호출 (기본값: octree_resolution=256, num_inference_steps=8, guidance_scale=5.0, face_count=40000, texture=false)<br>결과는 FileAttachment로 저장 |
+| Get Generated 3D Model | 생성된 3D 모델 조회 | GET | /api/ai/3d-models/{id} | – | `{"id":1,"resultId":"res-1","fileId":101,"fileUrl":"/models/1.glb"}` | FileAttachment 정보 포함 |
+| Delete Generated 3D Model | 생성된 3D 모델 삭제 | DELETE | /api/ai/3d-models/{id} | – | `204 No Content` | FileAttachment 및 기록 삭제 |
 | Start Chat Session | 챗봇 세션 생성 | POST | /api/ai/chat/sessions | `{"patentId":1,"sessionType":"CHECK"}` | `{"sessionId":1,"startedAt":"2024-01-01T09:00:00Z"}` | sessionType: ex. "CHECK", "DRAFT" |
 | Send Chat Message | AI 챗봇 메시지 전송 + 기능 실행 요청 | POST | /api/ai/chat/sessions/{sessionId}/messages | `{"message":"안녕하세요","requestedFeatures":["CHECK"]}` | `{"messageId":1,"sender":"USER","content":"답변","executedFeatures":["CHECK"],"featuresResult":{},"createdAt":"2024-01-01T09:01:00Z"}` | AI_ChatMessage, AI_ActionLog 포함 |
 | Get Chat History | 특정 챗봇 세션 대화 내역 조회 | GET | /api/ai/chat/sessions/{sessionId}/messages | – | `[{"messageId":1,"sender":"USER","content":"안녕하세요","executedFeatures":[],"featuresResult":{},"createdAt":"2024-01-01T09:01:00Z"}]` | session 단위 대화 이력 제공 |


### PR DESCRIPTION
## Summary
- persist generated 3D model files as `FileAttachment` records linked to the source attachment
- expose GET and DELETE endpoints returning attachment metadata for generated models
- document 3D model APIs with new response fields and retrieval/deletion operations

## Testing
- `./gradlew test` *(fails: constructor PatentService cannot be applied; SubmitPatentResponse cannot be converted to PatentResponse)*

------
https://chatgpt.com/codex/tasks/task_e_68997c22e2288320b649dab13051cf8b