### PR TITLE
Persist GLTF output from 3D model API

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -8,9 +8,9 @@ group = 'com.patentsight'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+        toolchain {
+                languageVersion = JavaLanguageVersion.of(17)
+        }
 }
 
 configurations {
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-webflux'
+        implementation 'org.springframework:spring-test'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/patentsight/ai/client/ThreeDModelApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/client/ThreeDModelApiClient.java
@@ -1,26 +1,35 @@
 package com.patentsight.ai.client;
 
-import com.patentsight.ai.dto.Generate3DModelApiResponse;
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import com.patentsight.ai.dto.Generate3DModelApiResponse;
+
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
 
 @Component
 public class ThreeDModelApiClient {
     private final WebClient webClient;
 
+    private static final MediaType GLB = MediaType.parseMediaType("model/gltf-binary");
+
     public ThreeDModelApiClient(WebClient.Builder builder) {
         this.webClient = builder.baseUrl("https://090afeef334a.ngrok-free.app").build();
     }
 
-    public Mono<Generate3DModelApiResponse> generate(Path imagePath) {
+    public Mono<Path> generate(Path imagePath, Path saveDir) {
         FileSystemResource image = new FileSystemResource(imagePath);
         MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
         form.add("file", image);
@@ -34,7 +43,40 @@ public class ThreeDModelApiClient {
                 .uri("/generate")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData(form))
-                .retrieve()
-                .bodyToMono(Generate3DModelApiResponse.class);
+                .accept(GLB, MediaType.APPLICATION_OCTET_STREAM, MediaType.APPLICATION_JSON)
+                .exchangeToMono(response -> {
+                    MediaType contentType = response.headers().contentType()
+                            .orElse(MediaType.APPLICATION_OCTET_STREAM);
+
+                    if (MediaType.APPLICATION_JSON.isCompatibleWith(contentType)) {
+                        return response.bodyToMono(Generate3DModelApiResponse.class)
+                                .flatMap(r -> Mono.error(new IllegalStateException("JSON response not expected")));
+                    }
+
+                    if (GLB.isCompatibleWith(contentType) || MediaType.APPLICATION_OCTET_STREAM.isCompatibleWith(contentType)) {
+                        String filename = extractFilename(response.headers().asHttpHeaders())
+                                .orElse("model-" + UUID.randomUUID() + ".glb");
+                        try {
+                            Files.createDirectories(saveDir);
+                        } catch (Exception ignored) {
+                        }
+                        Path target = saveDir.resolve(filename);
+                        return response.body(BodyExtractors.toDataBuffers())
+                                .as(data -> DataBufferUtils.write(data, target))
+                                .then(Mono.just(target));
+                    }
+
+                    return response.createException().flatMap(Mono::error);
+                });
+    }
+
+    private Optional<String> extractFilename(HttpHeaders headers) {
+        return Optional.ofNullable(headers.getFirst(HttpHeaders.CONTENT_DISPOSITION))
+                .flatMap(cd -> {
+                    int idx = cd.indexOf("filename=");
+                    if (idx < 0) return Optional.empty();
+                    String fn = cd.substring(idx + 9).replace("\"", "").trim();
+                    return Optional.of(fn.isEmpty() ? null : fn);
+                });
     }
 }

--- a/backend/src/main/java/com/patentsight/ai/client/ThreeDModelApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/client/ThreeDModelApiClient.java
@@ -26,7 +26,7 @@ public class ThreeDModelApiClient {
     private static final MediaType GLB = MediaType.parseMediaType("model/gltf-binary");
 
     public ThreeDModelApiClient(WebClient.Builder builder) {
-        this.webClient = builder.baseUrl("https://090afeef334a.ngrok-free.app").build();
+        this.webClient = builder.baseUrl("https://778efa9bea99.ngrok-free.app").build();
     }
 
     public Mono<Path> generate(Path imagePath, Path saveDir) {

--- a/backend/src/main/java/com/patentsight/ai/dto/Generated3DModelResponse.java
+++ b/backend/src/main/java/com/patentsight/ai/dto/Generated3DModelResponse.java
@@ -1,27 +1,27 @@
 package com.patentsight.ai.dto;
 
 public class Generated3DModelResponse {
-    private String resultId;
-    private String filePath;
+    private Long fileId;
+    private String fileUrl;
 
-    public Generated3DModelResponse(String resultId, String filePath) {
-        this.resultId = resultId;
-        this.filePath = filePath;
+    public Generated3DModelResponse(Long fileId, String fileUrl) {
+        this.fileId = fileId;
+        this.fileUrl = fileUrl;
     }
 
-    public String getResultId() {
-        return resultId;
+    public Long getFileId() {
+        return fileId;
     }
 
-    public void setResultId(String resultId) {
-        this.resultId = resultId;
+    public void setFileId(Long fileId) {
+        this.fileId = fileId;
     }
 
-    public String getFilePath() {
-        return filePath;
+    public String getFileUrl() {
+        return fileUrl;
     }
 
-    public void setFilePath(String filePath) {
-        this.filePath = filePath;
+    public void setFileUrl(String fileUrl) {
+        this.fileUrl = fileUrl;
     }
 }

--- a/backend/src/test/java/com/patentsight/ai/service/impl/AiImageServiceImplTest.java
+++ b/backend/src/test/java/com/patentsight/ai/service/impl/AiImageServiceImplTest.java
@@ -1,0 +1,64 @@
+package com.patentsight.ai.service.impl;
+
+import com.patentsight.ai.client.ThreeDModelApiClient;
+import com.patentsight.ai.dto.Generated3DModelResponse;
+import com.patentsight.ai.dto.ImageIdRequest;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.service.FileService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Mono;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AiImageServiceImplTest {
+
+    @Mock
+    private ThreeDModelApiClient apiClient;
+
+    @Mock
+    private FileService fileService;
+
+    @InjectMocks
+    private AiImageServiceImpl service;
+
+    @Test
+    void generate3DModelPersistsGltfFile() throws Exception {
+        byte[] gltf = new byte[]{0x0, 0x1};
+        Path tmp = Files.createTempFile("image-1", ".glb");
+        Files.write(tmp, gltf);
+        when(apiClient.generate(any(), any())).thenReturn(Mono.just(tmp));
+
+        FileResponse fileRes = new FileResponse();
+        fileRes.setFileId(5L);
+        fileRes.setFileUrl("path/model.glb");
+        when(fileService.create(any(), isNull(), eq(123L))).thenReturn(fileRes);
+
+        ImageIdRequest req = new ImageIdRequest();
+        req.setImageId("image-1");
+        req.setPatentId(123L);
+
+        Generated3DModelResponse res = service.generate3DModel(req);
+
+        assertEquals(5L, res.getFileId());
+        assertEquals("path/model.glb", res.getFileUrl());
+
+        ArgumentCaptor<MultipartFile> captor = ArgumentCaptor.forClass(MultipartFile.class);
+        verify(fileService).create(captor.capture(), isNull(), eq(123L));
+        MultipartFile saved = captor.getValue();
+        assertTrue(saved.getOriginalFilename().endsWith(".glb"));
+        assertEquals("model/gltf-binary", saved.getContentType());
+        assertArrayEquals(gltf, saved.getBytes());
+    }
+}


### PR DESCRIPTION
## Summary
- Stream 3D model API GLB responses to disk based on `Content-Type`
- Persist generated GLB via `FileService` and expose file metadata
- Verify GLB persistence in `AiImageServiceImpl` unit tests and use Java 17 toolchain

## Testing
- `./gradlew test` *(fails: Could not resolve org.projectlombok:lombok:1.18.38; trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68999d2a267c83208ff889e1c054bb98