### PR TITLE
Use file service image path for 3D model generation

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
@@ -7,6 +7,8 @@ import com.patentsight.file.dto.FileResponse;
 import com.patentsight.file.service.FileService;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
 import java.io.IOException;
@@ -37,8 +39,13 @@ public class AiImageServiceImpl implements AiImageService {
 
     @Override
     public Generated3DModelResponse generate3DModel(ImageIdRequest request) {
+        FileResponse image = fileService.get(Long.valueOf(request.getImageId()));
+        if (image == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Image not found: " + request.getImageId());
+        }
+        Path imagePath = Paths.get(image.getFileUrl());
         Mono<Path> mono = threeDModelApiClient.generate(
-                Paths.get("uploads", request.getImageId() + ".jpg"),
+                imagePath,
                 Paths.get("uploads"));
         Path glbPath = mono.block();
         if (glbPath == null) {

--- a/backend/src/test/java/com/patentsight/ai/service/impl/AiImageServiceImplTest.java
+++ b/backend/src/test/java/com/patentsight/ai/service/impl/AiImageServiceImplTest.java
@@ -38,7 +38,12 @@ class AiImageServiceImplTest {
         byte[] gltf = new byte[]{0x0, 0x1};
         Path tmp = Files.createTempFile("image-1", ".glb");
         Files.write(tmp, gltf);
-        when(apiClient.generate(any(), any())).thenReturn(Mono.just(tmp));
+        Path imagePath = Files.createTempFile("image", ".jpg");
+        when(apiClient.generate(eq(imagePath), any())).thenReturn(Mono.just(tmp));
+
+        FileResponse imageRes = new FileResponse();
+        imageRes.setFileUrl(imagePath.toString());
+        when(fileService.get(1L)).thenReturn(imageRes);
 
         FileResponse fileRes = new FileResponse();
         fileRes.setFileId(5L);
@@ -46,7 +51,7 @@ class AiImageServiceImplTest {
         when(fileService.create(any(), isNull(), eq(123L))).thenReturn(fileRes);
 
         ImageIdRequest req = new ImageIdRequest();
-        req.setImageId("image-1");
+        req.setImageId("1");
         req.setPatentId(123L);
 
         Generated3DModelResponse res = service.generate3DModel(req);


### PR DESCRIPTION
## Summary
- Lookup image files via FileService before generating 3D models and throw a 404 when missing
- Update 3D model generation to use fetched image path
- Adjust unit test to mock FileService.get and supply numeric image ID

## Testing
- `./gradlew test -Dorg.gradle.java.home=/usr/lib/jvm/jdk-17.0.12+7` *(fails: Could not resolve org.projectlombok:lombok:1.18.38 - PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_6899a76748cc8320af526b1b9f8432f6