### PR TITLE
Add endpoint to retrieve generated 3D models

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/controller/AiImageController.java
+++ b/backend/src/main/java/com/patentsight/ai/controller/AiImageController.java
@@ -2,6 +2,7 @@ package com.patentsight.ai.controller;
 
 import com.patentsight.ai.dto.*;
 import com.patentsight.ai.service.AiImageService;
+import com.patentsight.file.dto.FileResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,6 +29,15 @@ public class AiImageController {
     public ResponseEntity<Generated3DModelResponse> generate3DModel(
             @RequestBody ImageIdRequest request) {
         Generated3DModelResponse response = aiImageService.generate3DModel(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/3d-models/{id}")
+    public ResponseEntity<FileResponse> getGenerated3DModel(@PathVariable("id") Long id) {
+        FileResponse response = aiImageService.getGenerated3DModel(id);
+        if (response == null) {
+            return ResponseEntity.notFound().build();
+        }
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/patentsight/ai/service/AiImageService.java
+++ b/backend/src/main/java/com/patentsight/ai/service/AiImageService.java
@@ -4,6 +4,7 @@ import com.patentsight.ai.dto.ImageSimilarityRequest;
 import com.patentsight.ai.dto.ImageSimilarityResponse;
 import com.patentsight.ai.dto.ImageIdRequest;
 import com.patentsight.ai.dto.Generated3DModelResponse;
+import com.patentsight.file.dto.FileResponse;
 
 import java.util.List;
 
@@ -12,4 +13,6 @@ public interface AiImageService {
     List<ImageSimilarityResponse> analyzeImageSimilarity(ImageSimilarityRequest request);
 
     Generated3DModelResponse generate3DModel(ImageIdRequest request);
+
+    FileResponse getGenerated3DModel(Long id);
 }

--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
@@ -66,4 +66,9 @@ public class AiImageServiceImpl implements AiImageService {
             throw new RuntimeException("Failed to read generated model", e);
         }
     }
+
+    @Override
+    public FileResponse getGenerated3DModel(Long id) {
+        return fileService.get(id);
+    }
 }

--- a/backend/src/test/java/com/patentsight/ai/service/impl/AiImageServiceImplTest.java
+++ b/backend/src/test/java/com/patentsight/ai/service/impl/AiImageServiceImplTest.java
@@ -66,4 +66,16 @@ class AiImageServiceImplTest {
         assertEquals("model/gltf-binary", saved.getContentType());
         assertArrayEquals(gltf, saved.getBytes());
     }
+
+    @Test
+    void getGenerated3DModelDelegatesToFileService() {
+        FileResponse fileRes = new FileResponse();
+        fileRes.setFileId(10L);
+        when(fileService.get(10L)).thenReturn(fileRes);
+
+        FileResponse res = service.getGenerated3DModel(10L);
+
+        assertEquals(10L, res.getFileId());
+        verify(fileService).get(10L);
+    }
 }


### PR DESCRIPTION
## Summary
- add REST endpoint to fetch generated 3D models by id
- support retrieving stored models through service layer
- cover retrieval logic with unit test

## Testing
- `bash ./gradlew test` *(fails: PatentServiceTest compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899b1de5f348320b1b76bd6a6c721ef