### PR TITLE
feat: remove patentId from claim draft API

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/controller/AiDraftController.java
+++ b/backend/src/main/java/com/patentsight/ai/controller/AiDraftController.java
@@ -21,7 +21,7 @@ public class AiDraftController {
     // ✅ 1. 청구항 초안 생성
     @PostMapping("/drafts/claims")
     public DraftDetailResponse generateClaimDraft(@RequestBody ClaimDraftRequest request) {
-        return aiService.generateClaimDraft(request.getPatentId(), request.getQuery(), request.getTopK());
+        return aiService.generateClaimDraft(request.getQuery(), request.getTopK());
     }
 
     // ✅ 2. 초안 생성 (거절)
@@ -78,17 +78,8 @@ public class AiDraftController {
     }
 
     public static class ClaimDraftRequest {
-        private Long patentId;
         private String query;
         private Integer topK;
-
-        public Long getPatentId() {
-            return patentId;
-        }
-
-        public void setPatentId(Long patentId) {
-            this.patentId = patentId;
-        }
 
         public String getQuery() {
             return query;

--- a/backend/src/main/java/com/patentsight/ai/service/AiService.java
+++ b/backend/src/main/java/com/patentsight/ai/service/AiService.java
@@ -5,5 +5,5 @@ import com.patentsight.ai.dto.DraftDetailResponse;
 public interface AiService {
     DraftDetailResponse generateRejectionDraft(Long patentId, Long fileId);
 
-    DraftDetailResponse generateClaimDraft(Long patentId, String query, Integer topK);
+    DraftDetailResponse generateClaimDraft(String query, Integer topK);
 }

--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiServiceImpl.java
@@ -38,9 +38,9 @@ public class AiServiceImpl implements AiService {
     }
 
     @Override
-    public DraftDetailResponse generateClaimDraft(Long patentId, String query, Integer topK) {
+    public DraftDetailResponse generateClaimDraft(String query, Integer topK) {
         String raw = claimDraftClient.generate(query, topK);
         String claimsText = claimDraftClient.extractClaims(raw);
-        return draftService.createAndReturnDraft(patentId, DraftType.CLAIM, claimsText);
+        return draftService.createAndReturnDraft(null, DraftType.CLAIM, claimsText);
     }
 }

--- a/docs/patent-api.md
+++ b/docs/patent-api.md
@@ -52,7 +52,7 @@
 
 | API 이름 | 설명 | Method | URL | 요청 데이터 | 응답 데이터 | 비고 |
 | --- | --- | --- | --- | --- | --- | --- |
-| Generate Claim Draft | 청구항 초안 생성 | POST | /api/ai/drafts/claims | `{ "patent_id":1,"query":"자율주행 차량의 객체 인식 취약점 보완 장치 및 방법","top_k":5 }` | `{ "log_id":"1","rag_context":[{"rank":1,"score":0.98,"app_num":"1020050050443","claim_num":1,"text":"…"}],"title":"…","summary":"…","technicalField":"…","backgroundTechnology":"…","inventionDetails":{"problemToSolve":"…","solution":"…","effect":"…"},"claims":["[청구항 1]...","[청구항 2]..."] }` | 외부 청구항 생성 API 호출<br>(기본값: minimal=true, include_rag_meta=true, rag_format=meta)<br>생성된 초안은 Draft로 저장되며 AI_ActionLog 및 AI_ChatMessage에 기록 |
+| Generate Claim Draft | 청구항 초안 생성 | POST | /api/ai/drafts/claims | `{ "query":"자율주행 차량의 객체 인식 취약점 보완 장치 및 방법","top_k":5 }` | `{ "log_id":"1","rag_context":[{"rank":1,"score":0.98,"app_num":"1020050050443","claim_num":1,"text":"…"}],"title":"…","summary":"…","technicalField":"…","backgroundTechnology":"…","inventionDetails":{"problemToSolve":"…","solution":"…","effect":"…"},"claims":["[청구항 1]...","[청구항 2]..."] }` | 외부 청구항 생성 API 호출<br>(기본값: minimal=true, include_rag_meta=true, rag_format=meta)<br>생성된 초안은 Draft로 저장되며 AI_ActionLog 및 AI_ChatMessage에 기록 |
 | Generate Rejection Draft | 거절 사유 초안 생성 | POST | /api/ai/drafts/rejections | `{ "patentId":1 }` | `{ "logId":2,"draftText":"거절 사유 초안" }` | 구조 동일 |
 | List Drafts | 출원별 생성된 초안 목록 조회 | GET | /api/ai/drafts?patentId={patentId} | – | `[ { "draftId":1,"type":"CLAIM","content":"청구항 초안" } ]` | type: "CLAIM" 또는 "REJECTION", 최신순 정렬 |
 | Delete Drafts | 생성된 초안 삭제 | DELETE | /api/ai/drafts?patentId={patentId} | – | – |  |

--- a/frontend/applicant_fe/src/api/patents.js
+++ b/frontend/applicant_fe/src/api/patents.js
@@ -78,9 +78,9 @@ export const getLatestDocument = async (patentId) => {
 
 // 이하 모든 AI 관련 및 기타 함수들도 동일한 패턴으로 수정합니다.
 
-export const generateClaimDraft = async (patentId) => {
+export const generateClaimDraft = async ({ query, topK }) => {
   try {
-    const res = await axios.post('/api/ai/draft/claims', { patent_id: patentId });
+    const res = await axios.post('/api/ai/drafts/claims', { query, topK });
     return res.data;
   } catch (error) {
     console.error('청구항 초안 생성 실패:', error);


### PR DESCRIPTION
## Summary
- stop requiring `patentId` when generating claim drafts
- adjust frontend helper and docs to use `query` and `topK` only

## Testing
- `sh gradlew test` *(fails: Cannot find a Java installation)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bfe73227883208ade15bb37c3a9ac