### PR TITLE
Fix ClaimDraftClient to use absolute URI

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,12 +34,7 @@ public class ClaimDraftClient {
         }
 
         String response = webClient.post()
-                .uri(uriBuilder -> uriBuilder
-                        .path(CLAIM_API_URL)
-                        .queryParam("minimal", true)
-                        .queryParam("include_rag_meta", true)
-                        .queryParam("rag_format", "meta")
-                        .build())
+                .uri(URI.create(CLAIM_API_URL + "?minimal=true&include_rag_meta=true&rag_format=meta"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(body)
                 .retrieve()


### PR DESCRIPTION
## Summary
- Ensure WebClient calls claim-generation API with a full URI including scheme and host.

## Testing
- `./gradlew test` *(fails: Could not resolve org.projectlombok:lombok due to `java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty`)*

------
https://chatgpt.com/codex/tasks/task_e_689c224479588320839e32390fa656b0