### PR TITLE
Parse claim draft response into structured DTO

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/controller/AiDraftController.java
+++ b/backend/src/main/java/com/patentsight/ai/controller/AiDraftController.java
@@ -1,5 +1,6 @@
 package com.patentsight.ai.controller;
 
+import com.patentsight.ai.dto.ClaimDraftDetails;
 import com.patentsight.ai.dto.DraftDetailResponse;
 import com.patentsight.ai.dto.DraftListResponse;
 import com.patentsight.ai.dto.DraftUpdateRequest;
@@ -20,7 +21,7 @@ public class AiDraftController {
 
     // ✅ 1. 청구항 초안 생성
     @PostMapping("/drafts/claims")
-    public DraftDetailResponse generateClaimDraft(@RequestBody ClaimDraftRequest request) {
+    public ClaimDraftDetails generateClaimDraft(@RequestBody ClaimDraftRequest request) {
         return aiService.generateClaimDraft(request.getQuery(), request.getTopK());
     }
 

--- a/backend/src/main/java/com/patentsight/ai/dto/ClaimDraftDetails.java
+++ b/backend/src/main/java/com/patentsight/ai/dto/ClaimDraftDetails.java
@@ -1,0 +1,59 @@
+package com.patentsight.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * DTO representing claim draft details returned from the external AI service.
+ */
+@Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClaimDraftDetails {
+
+    @JsonProperty("log_id")
+    private String logId;
+
+    @JsonProperty("rag_context")
+    private List<RagContext> ragContext;
+
+    private String title;
+    private String summary;
+    private String technicalField;
+    private String backgroundTechnology;
+
+    @JsonProperty("inventionDetails")
+    private InventionDetails inventionDetails;
+
+    private List<String> claims;
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RagContext {
+        private Integer rank;
+        private Double score;
+
+        @JsonProperty("app_num")
+        private String appNum;
+
+        @JsonProperty("claim_num")
+        private Integer claimNum;
+
+        private String text;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class InventionDetails {
+        private String problemToSolve;
+        private String solution;
+        private String effect;
+    }
+}
+

--- a/backend/src/main/java/com/patentsight/ai/service/AiService.java
+++ b/backend/src/main/java/com/patentsight/ai/service/AiService.java
@@ -1,9 +1,10 @@
 package com.patentsight.ai.service;
 
+import com.patentsight.ai.dto.ClaimDraftDetails;
 import com.patentsight.ai.dto.DraftDetailResponse;
 
 public interface AiService {
     DraftDetailResponse generateRejectionDraft(Long patentId, Long fileId);
 
-    DraftDetailResponse generateClaimDraft(String query, Integer topK);
+    ClaimDraftDetails generateClaimDraft(String query, Integer topK);
 }

--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiServiceImpl.java
@@ -1,6 +1,7 @@
 package com.patentsight.ai.service.impl;
 
 import com.patentsight.ai.domain.DraftType;
+import com.patentsight.ai.dto.ClaimDraftDetails;
 import com.patentsight.ai.dto.DraftDetailResponse;
 import com.patentsight.ai.service.AiService;
 import com.patentsight.ai.service.DraftService;
@@ -38,9 +39,8 @@ public class AiServiceImpl implements AiService {
     }
 
     @Override
-    public DraftDetailResponse generateClaimDraft(String query, Integer topK) {
+    public ClaimDraftDetails generateClaimDraft(String query, Integer topK) {
         String raw = claimDraftClient.generate(query, topK);
-        String claimsText = claimDraftClient.extractClaims(raw);
-        return draftService.createAndReturnDraft(null, DraftType.CLAIM, claimsText);
+        return claimDraftClient.parseDetails(raw);
     }
 }

--- a/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
@@ -2,6 +2,7 @@ package com.patentsight.ai.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.patentsight.ai.dto.ClaimDraftDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -10,8 +11,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -46,24 +51,57 @@ public class ClaimDraftClient {
     }
 
     /**
-     * 응답 JSON에서 claims 배열만 추출해 하나의 문자열로 합쳐서 반환한다.
+     * 응답 JSON을 {@link ClaimDraftDetails} 객체로 파싱한다.
      */
-    public String extractClaims(String json) {
+    public ClaimDraftDetails parseDetails(String json) {
         try {
             ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(json);
-            JsonNode claims = root.path("claims");
-            if (!claims.isArray()) {
-                return json; // 예상치 못한 응답 구조인 경우 원본 반환
+
+            ClaimDraftDetails details = new ClaimDraftDetails();
+            details.setLogId(root.path("log_id").asText(null));
+
+            // RAG context
+            if (root.has("rag_context") && root.get("rag_context").isArray()) {
+                List<ClaimDraftDetails.RagContext> contexts = new ArrayList<>();
+                for (JsonNode ctx : root.get("rag_context")) {
+                    ClaimDraftDetails.RagContext rc = new ClaimDraftDetails.RagContext();
+                    if (ctx.has("rank")) rc.setRank(ctx.get("rank").asInt());
+                    if (ctx.has("score")) rc.setScore(ctx.get("score").asDouble());
+                    rc.setAppNum(ctx.path("app_num").asText(null));
+                    if (ctx.has("claim_num")) rc.setClaimNum(ctx.get("claim_num").asInt());
+                    rc.setText(ctx.path("text").asText(null));
+                    contexts.add(rc);
+                }
+                details.setRagContext(contexts);
             }
-            StringBuilder sb = new StringBuilder();
-            for (JsonNode node : claims) {
-                sb.append(node.asText()).append("\n");
+
+            // Sections
+            JsonNode sections = root.path("sections_parsed");
+            details.setTitle(sections.path("발명의 명칭").asText(null));
+            details.setSummary(sections.path("요약").asText(null));
+            details.setTechnicalField(sections.path("기술 분야").asText(null));
+            details.setBackgroundTechnology(sections.path("배경 기술").asText(null));
+
+            ClaimDraftDetails.InventionDetails inv = new ClaimDraftDetails.InventionDetails();
+            inv.setProblemToSolve(sections.path("해결하려는 과제").asText(null));
+            inv.setSolution(sections.path("과제의 해결 수단").asText(null));
+            inv.setEffect(sections.path("발명의 효과").asText(null));
+            details.setInventionDetails(inv);
+
+            String claimsText = sections.path("청구항").asText("");
+            if (!claimsText.isEmpty()) {
+                List<String> claims = Arrays.stream(claimsText.split("\\n\\n"))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+                details.setClaims(claims);
             }
-            return sb.toString().trim();
+
+            return details;
         } catch (Exception e) {
             log.warn("Failed to parse claim draft response", e);
-            return json;
+            return new ClaimDraftDetails();
         }
     }
 }


### PR DESCRIPTION
## Summary
- ignore extra fields in ClaimDraftDetails DTO
- map external API response to structured ClaimDraftDetails

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation on your machine)*

------
https://chatgpt.com/codex/tasks/task_e_689c280ddbb88320875dd027602ea5ba