### PR TITLE
Parse claim draft response before returning

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/controller/AiDraftController.java
+++ b/backend/src/main/java/com/patentsight/ai/controller/AiDraftController.java
@@ -6,6 +6,7 @@ import com.patentsight.ai.dto.DraftListResponse;
 import com.patentsight.ai.dto.DraftUpdateRequest;
 import com.patentsight.ai.service.AiService;
 import com.patentsight.ai.service.DraftService;
+import com.patentsight.ai.util.ClaimDraftClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,11 +19,13 @@ public class AiDraftController {
 
     private final AiService aiService;
     private final DraftService draftService;
+    private final ClaimDraftClient claimDraftClient;
 
     // ✅ 1. 청구항 초안 생성
     @PostMapping("/drafts/claims")
     public ClaimDraftDetails generateClaimDraft(@RequestBody ClaimDraftRequest request) {
-        return aiService.generateClaimDraft(request.getQuery(), request.getTopK());
+        String raw = aiService.generateClaimDraft(request.getQuery(), request.getTopK());
+        return claimDraftClient.parseDetails(raw);
     }
 
     // ✅ 2. 초안 생성 (거절)

--- a/backend/src/main/java/com/patentsight/ai/dto/ClaimDraftDetails.java
+++ b/backend/src/main/java/com/patentsight/ai/dto/ClaimDraftDetails.java
@@ -3,6 +3,7 @@ package com.patentsight.ai.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -15,6 +16,16 @@ import java.util.List;
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "log_id",
+        "rag_context",
+        "title",
+        "summary",
+        "technicalField",
+        "backgroundTechnology",
+        "inventionDetails",
+        "claims"
+})
 public class ClaimDraftDetails {
 
     @JsonProperty("log_id")

--- a/backend/src/main/java/com/patentsight/ai/service/AiService.java
+++ b/backend/src/main/java/com/patentsight/ai/service/AiService.java
@@ -1,10 +1,9 @@
 package com.patentsight.ai.service;
 
-import com.patentsight.ai.dto.ClaimDraftDetails;
 import com.patentsight.ai.dto.DraftDetailResponse;
 
 public interface AiService {
     DraftDetailResponse generateRejectionDraft(Long patentId, Long fileId);
 
-    ClaimDraftDetails generateClaimDraft(String query, Integer topK);
+    String generateClaimDraft(String query, Integer topK);
 }

--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiServiceImpl.java
@@ -1,7 +1,6 @@
 package com.patentsight.ai.service.impl;
 
 import com.patentsight.ai.domain.DraftType;
-import com.patentsight.ai.dto.ClaimDraftDetails;
 import com.patentsight.ai.dto.DraftDetailResponse;
 import com.patentsight.ai.service.AiService;
 import com.patentsight.ai.service.DraftService;
@@ -39,8 +38,7 @@ public class AiServiceImpl implements AiService {
     }
 
     @Override
-    public ClaimDraftDetails generateClaimDraft(String query, Integer topK) {
-        String raw = claimDraftClient.generate(query, topK);
-        return claimDraftClient.parseDetails(raw);
+    public String generateClaimDraft(String query, Integer topK) {
+        return claimDraftClient.generate(query, topK);
     }
 }


### PR DESCRIPTION
## Summary
- return raw claim-draft JSON from service and parse it in controller
- expose claim draft client to controller for conversion

## Testing
- `./gradlew test` *(fails: package org.junit.jupiter.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689c39aee50883209284e3197a2008ec