### PR TITLE
feat: add 3d model generation

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,10 +33,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// ✅ Spring Security + JWT
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+        runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+        runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+        // Needed for MockMultipartFile
+        implementation 'org.springframework:spring-test'
 
 	// ✅ DB
 	runtimeOnly 'com.h2database:h2'
@@ -46,7 +49,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// PDFBox 라이브러리 추가
-	implementation 'org.apache.pdfbox:pdfbox:2.0.30'
+        implementation 'org.apache.pdfbox:pdfbox:2.0.30'
+
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 // ✅ 테스트 실행 비활성화

--- a/backend/src/main/java/com/patentsight/ai/client/ThreeDModelApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/client/ThreeDModelApiClient.java
@@ -1,0 +1,76 @@
+package com.patentsight.ai.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.patentsight.ai.dto.Generate3DModelApiResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class ThreeDModelApiClient {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String endpoint;
+    private final Path saveDir;
+
+    public ThreeDModelApiClient(RestTemplate restTemplate,
+                                @Value("${ai.3d-model.endpoint:https://778efa9bea99.ngrok-free.app/generate}") String endpoint,
+                                @Value("${ai.3d-model.save-dir:uploads}") String saveDir) {
+        this.restTemplate = restTemplate;
+        this.endpoint = endpoint;
+        this.saveDir = Path.of(saveDir);
+    }
+
+    public File generate(String imagePath) {
+        try {
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+            body.add("file", new FileSystemResource(imagePath));
+            body.add("octree_resolution", "256");
+            body.add("num_inference_steps", "8");
+            body.add("guidance_scale", "5.0");
+            body.add("face_count", "40000");
+            body.add("texture", "false");
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+            HttpEntity<MultiValueMap<String, Object>> entity = new HttpEntity<>(body, headers);
+            ResponseEntity<byte[]> res = restTemplate.exchange(endpoint, HttpMethod.POST, entity, byte[].class);
+            MediaType ct = res.getHeaders().getContentType();
+            byte[] data = res.getBody();
+            if (ct != null && ct.includes(MediaType.APPLICATION_JSON)) {
+                String json = new String(data);
+                Generate3DModelApiResponse error = objectMapper.readValue(json, Generate3DModelApiResponse.class);
+                throw new RuntimeException("3D model API error: " + error.getResultId());
+            }
+
+            String disposition = res.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION);
+            String filename = "result.glb";
+            if (disposition != null) {
+                Matcher matcher = Pattern.compile("filename=\"?([^\";]+)\"?").matcher(disposition);
+                if (matcher.find()) {
+                    filename = matcher.group(1);
+                }
+            }
+
+            Files.createDirectories(saveDir);
+            Path target = saveDir.resolve(filename);
+            Files.write(target, data);
+            return target.toFile();
+        } catch (IOException e) {
+            throw new RuntimeException("3D model generation failed", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/patentsight/ai/controller/AiImageController.java
+++ b/backend/src/main/java/com/patentsight/ai/controller/AiImageController.java
@@ -1,0 +1,33 @@
+package com.patentsight.ai.controller;
+
+import com.patentsight.ai.dto.Generated3DModelResponse;
+import com.patentsight.ai.dto.ImageIdRequest;
+import com.patentsight.ai.service.AiImageService;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+public class AiImageController {
+
+    private final AiImageService aiImageService;
+    private final FileService fileService;
+
+    @PostMapping("/3d-models")
+    public Generated3DModelResponse generate3DModel(@RequestBody ImageIdRequest request) {
+        return aiImageService.generate3DModel(request);
+    }
+
+    @GetMapping("/3d-models/{id}")
+    public ResponseEntity<FileResponse> getGenerated3DModel(@PathVariable Long id) {
+        FileResponse res = fileService.get(id);
+        if (res == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(res);
+    }
+}

--- a/backend/src/main/java/com/patentsight/ai/dto/Generate3DModelApiResponse.java
+++ b/backend/src/main/java/com/patentsight/ai/dto/Generate3DModelApiResponse.java
@@ -1,0 +1,22 @@
+package com.patentsight.ai.dto;
+
+public class Generate3DModelApiResponse {
+    private String resultId;
+    private String filePath;
+
+    public String getResultId() {
+        return resultId;
+    }
+
+    public void setResultId(String resultId) {
+        this.resultId = resultId;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+}

--- a/backend/src/main/java/com/patentsight/ai/dto/Generated3DModelResponse.java
+++ b/backend/src/main/java/com/patentsight/ai/dto/Generated3DModelResponse.java
@@ -1,27 +1,30 @@
 package com.patentsight.ai.dto;
 
 public class Generated3DModelResponse {
-    private String resultId;
-    private String filePath;
+    private Long fileId;
+    private String fileUrl;
 
-    public Generated3DModelResponse(String resultId, String filePath) {
-        this.resultId = resultId;
-        this.filePath = filePath;
+    public Generated3DModelResponse() {
     }
 
-    public String getResultId() {
-        return resultId;
+    public Generated3DModelResponse(Long fileId, String fileUrl) {
+        this.fileId = fileId;
+        this.fileUrl = fileUrl;
     }
 
-    public void setResultId(String resultId) {
-        this.resultId = resultId;
+    public Long getFileId() {
+        return fileId;
     }
 
-    public String getFilePath() {
-        return filePath;
+    public void setFileId(Long fileId) {
+        this.fileId = fileId;
     }
 
-    public void setFilePath(String filePath) {
-        this.filePath = filePath;
+    public String getFileUrl() {
+        return fileUrl;
+    }
+
+    public void setFileUrl(String fileUrl) {
+        this.fileUrl = fileUrl;
     }
 }

--- a/backend/src/main/java/com/patentsight/ai/service/AiImageService.java
+++ b/backend/src/main/java/com/patentsight/ai/service/AiImageService.java
@@ -1,0 +1,8 @@
+package com.patentsight.ai.service;
+
+import com.patentsight.ai.dto.Generated3DModelResponse;
+import com.patentsight.ai.dto.ImageIdRequest;
+
+public interface AiImageService {
+    Generated3DModelResponse generate3DModel(ImageIdRequest request);
+}

--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
@@ -1,0 +1,54 @@
+package com.patentsight.ai.service.impl;
+
+import com.patentsight.ai.client.ThreeDModelApiClient;
+import com.patentsight.ai.dto.Generated3DModelResponse;
+import com.patentsight.ai.dto.ImageIdRequest;
+import com.patentsight.ai.service.AiImageService;
+import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class AiImageServiceImpl implements AiImageService {
+
+    private final FileService fileService;
+    private final ThreeDModelApiClient threeDModelApiClient;
+
+    @Override
+    public Generated3DModelResponse generate3DModel(ImageIdRequest request) {
+        FileAttachment image;
+        try {
+            image = fileService.findById(Long.parseLong(request.getImageId()));
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Original image not found");
+        }
+
+        File glbFile = threeDModelApiClient.generate(image.getFileUrl());
+        if (glbFile == null || !glbFile.exists()) {
+            throw new RuntimeException("Failed to generate 3D model");
+        }
+
+        try (FileInputStream fis = new FileInputStream(glbFile)) {
+            MultipartFile multipartFile = new MockMultipartFile(
+                    glbFile.getName(),
+                    glbFile.getName(),
+                    "model/gltf-binary",
+                    fis);
+            FileResponse saved = fileService.create(multipartFile, null, request.getPatentId());
+            return new Generated3DModelResponse(saved.getFileId(), saved.getFileUrl());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store generated model", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/ai/service/impl/AiImageServiceImpl.java
@@ -1,6 +1,6 @@
 package com.patentsight.ai.service.impl;
 
-import com.patentsight.ai.client.ThreeDModelApiClient;
+import com.patentsight.ai.util.ThreeDModelApiClient;
 import com.patentsight.ai.dto.Generated3DModelResponse;
 import com.patentsight.ai.dto.ImageIdRequest;
 import com.patentsight.ai.service.AiImageService;

--- a/backend/src/main/java/com/patentsight/ai/util/ThreeDModelApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ThreeDModelApiClient.java
@@ -1,4 +1,4 @@
-package com.patentsight.ai.client;
+package com.patentsight.ai.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.patentsight.ai.dto.Generate3DModelApiResponse;

--- a/backend/src/test/java/com/patentsight/ai/controller/AiImageControllerTest.java
+++ b/backend/src/test/java/com/patentsight/ai/controller/AiImageControllerTest.java
@@ -1,0 +1,34 @@
+package com.patentsight.ai.controller;
+
+import com.patentsight.ai.service.AiImageService;
+import com.patentsight.file.service.FileService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AiImageController.class)
+class AiImageControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AiImageService aiImageService;
+
+    @MockBean
+    private FileService fileService;
+
+    @Test
+    void getGenerated3DModelReturnsBadRequestForInvalidId() throws Exception {
+        when(fileService.get(999L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/ai/3d-models/999"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/patentsight/ai/service/AiImageServiceImplTest.java
+++ b/backend/src/test/java/com/patentsight/ai/service/AiImageServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.patentsight.ai.service;
 
-import com.patentsight.ai.client.ThreeDModelApiClient;
+import com.patentsight.ai.util.ThreeDModelApiClient;
 import com.patentsight.ai.dto.ImageIdRequest;
 import com.patentsight.ai.service.impl.AiImageServiceImpl;
 import com.patentsight.file.domain.FileAttachment;

--- a/backend/src/test/java/com/patentsight/ai/service/AiImageServiceImplTest.java
+++ b/backend/src/test/java/com/patentsight/ai/service/AiImageServiceImplTest.java
@@ -1,0 +1,64 @@
+package com.patentsight.ai.service;
+
+import com.patentsight.ai.client.ThreeDModelApiClient;
+import com.patentsight.ai.dto.ImageIdRequest;
+import com.patentsight.ai.service.impl.AiImageServiceImpl;
+import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.service.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AiImageServiceImplTest {
+
+    @Mock
+    private FileService fileService;
+    @Mock
+    private ThreeDModelApiClient threeDModelApiClient;
+    @InjectMocks
+    private AiImageServiceImpl aiImageService;
+
+    @BeforeEach
+    void setup() {
+        aiImageService = new AiImageServiceImpl(fileService, threeDModelApiClient);
+    }
+
+    @Test
+    void generate3DModelPersistsGltfFile() throws Exception {
+        ImageIdRequest req = new ImageIdRequest();
+        req.setPatentId(1L);
+        req.setImageId("10");
+
+        FileAttachment img = new FileAttachment();
+        img.setFileId(10L);
+        img.setFileUrl("uploads/original.png");
+        when(fileService.findById(10L)).thenReturn(img);
+
+        File glb = File.createTempFile("model", ".glb");
+        Files.writeString(glb.toPath(), "glb");
+        when(threeDModelApiClient.generate("uploads/original.png")).thenReturn(glb);
+
+        FileResponse saved = new FileResponse();
+        saved.setFileId(42L);
+        saved.setFileUrl("/uploads/42_generated.glb");
+        when(fileService.create(any(MultipartFile.class), isNull(), eq(1L))).thenReturn(saved);
+
+        aiImageService.generate3DModel(req);
+
+        verify(fileService).create(any(MultipartFile.class), isNull(), eq(1L));
+
+        glb.delete();
+    }
+}


### PR DESCRIPTION
## Summary
- add AI controller endpoint for 3D model generation and retrieval
- implement service and external API client to produce GLB files and save them
- include unit tests for service and controller

## Testing
- `sh backend/gradlew -p backend compileTestJava` *(fails: Could not determine the dependencies of task ':compileTestJava'. Cannot find a Java installation matching languageVersion=17)*
- `sh backend/gradlew -p backend test` *(fails: Could not determine the dependencies of task ':test'. Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_689c49a631ec8320b7fc5189daa6b3f1