### PR TITLE
Configure S3 file storage and RDS database

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,18 @@ This repository contains a sample structure for a patent management service. The
 - [Database ERD](docs/ERD.md)
 - [Patent API Specification](docs/patent-api.md)
 
+## AWS configuration
+
+The backend stores uploaded files in Amazon S3 and persists other data in an
+RDS PostgreSQL instance. Set the following environment variables or adjust the
+config files:
+
+```
+S3_BUCKET=your-s3-bucket
+AWS_REGION=us-east-1
+```
+
+The RDS connection can be configured in
+`backend/src/main/resources/application.yml` using placeholders such as
+`jdbc:postgresql://your-rds-endpoint:5432/your_database`.
+

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,8 +41,8 @@ dependencies {
         // Needed for MockMultipartFile
         implementation 'org.springframework:spring-test'
 
-	// ✅ DB
-	runtimeOnly 'com.h2database:h2'
+        // ✅ DB (PostgreSQL RDS)
+        implementation 'org.postgresql:postgresql:42.7.3'
 
 	// ✅ Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/patentsight/global/util/FileUtil.java
+++ b/backend/src/main/java/com/patentsight/global/util/FileUtil.java
@@ -16,12 +16,12 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
  * Utility helpers for storing uploaded files. Instead of writing to the local
  * file system this implementation stores objects in Amazon S3. The bucket name
  * and region are read from the {@code S3_BUCKET} and {@code AWS_REGION}
- * environment variables (defaults: {@code patentsight-artifacts-usea1} and
+ * environment variables (defaults: {@code your-s3-bucket} and
  * {@code us-east-1}).
  */
 public class FileUtil {
 
-    private static final String BUCKET = System.getenv().getOrDefault("S3_BUCKET", "patentsight-artifacts-usea1");
+    private static final String BUCKET = System.getenv().getOrDefault("S3_BUCKET", "your-s3-bucket");
     private static final Region REGION = Region.of(System.getenv().getOrDefault("AWS_REGION", "us-east-1"));
     private static final S3Client S3 = S3Client.builder().region(REGION).build();
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,16 +1,9 @@
 spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-      settings:
-        web-allow-others: true # 콘솔 원격 임시로 허용(위험)
   datasource:
-    url: jdbc:h2:mem:testdb
-#    jdbc:h2:file:./data/testdb 데이터를 계속 유지하려면 변경
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:postgresql://your-rds-endpoint:5432/your_database
+    driver-class-name: org.postgresql.Driver
+    username: your-db-username
+    password: your-db-password
 
   jpa:
     hibernate:


### PR DESCRIPTION
## Summary
- Store uploaded files on Amazon S3 using a configurable `S3_BUCKET`
- Switch application datasource to Amazon RDS PostgreSQL via placeholders
- Replace H2 dependency with PostgreSQL driver
- Document required AWS environment variables and RDS connection settings

## Testing
- `bash gradlew build` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_689d4b7d7c2c83208e002dcb7b37be6a