### PR TITLE
Fix review status enum usage

### DIFF
--- a/backend/src/main/java/com/patentsight/review/domain/Review.java
+++ b/backend/src/main/java/com/patentsight/review/domain/Review.java
@@ -26,7 +26,7 @@ public class Review {
     private User examiner;  // 심사관
 
     @Enumerated(EnumType.STRING)
-    private Decision decision; // APPROVE / PENDING / REJECT
+    private Decision decision; // SUBMITTED / REVIEWING / APPROVE / REJECT
 
     private String comment;
     private LocalDateTime reviewedAt;

--- a/backend/src/main/java/com/patentsight/review/dto/SubmitReviewRequest.java
+++ b/backend/src/main/java/com/patentsight/review/dto/SubmitReviewRequest.java
@@ -6,6 +6,6 @@ import lombok.*;
 @NoArgsConstructor @AllArgsConstructor @Builder
 public class SubmitReviewRequest {
     private Long patentId;          // 심사 대상 특허 ID
-    private String decision;        // APPROVE / REJECT / PENDING
+    private String decision;        // SUBMITTED / REVIEWING / APPROVE / REJECT
     private String comment;         // 심사 의견
 }

--- a/backend/src/main/java/com/patentsight/review/service/ReviewServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/review/service/ReviewServiceImpl.java
@@ -56,7 +56,8 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = new Review();
         review.setPatent(patent);
         review.setExaminer(examiner);
-        review.setDecision(Review.Decision.SUBMITTED); // PENDING을 SUBMITTED로 변경
+        // 초기 상태는 SUBMITTED로 설정
+        review.setDecision(Review.Decision.SUBMITTED);
         review.setReviewedAt(null);
         review.setAutoAssigned(false);
 
@@ -105,7 +106,8 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = new Review();
         review.setPatent(patent);
         review.setExaminer(examiner);
-        review.setDecision(Review.Decision.PENDING);
+        // 자동 배정된 리뷰도 초기 상태는 SUBMITTED
+        review.setDecision(Review.Decision.SUBMITTED);
         review.setAutoAssigned(true);
 
         reviewRepository.save(review);
@@ -169,7 +171,7 @@ public class ReviewServiceImpl implements ReviewService {
         return switch (decision) {
 
             case SUBMITTED -> PatentStatus.SUBMITTED;
-            case REVIEWING -> PatentStatus.REVIEWING; // PENDING을 SUBMITTED로 변경
+            case REVIEWING -> PatentStatus.REVIEWING;
             case APPROVE -> PatentStatus.APPROVED;
             case REJECT -> PatentStatus.REJECTED;
         };


### PR DESCRIPTION
## Summary
- replace obsolete PENDING status with SUBMITTED for auto-assigned reviews
- document valid review decisions

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 bash gradlew test` *(fails: Could not resolve org.projectlombok:lombok:1.18.38 due to trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_689da1ca95848320ab9e657d836927da