### PR TITLE
feat: centralize CORS origins

### DIFF
--- a/backend/src/main/java/com/patentsight/config/SecurityConfig.java
+++ b/backend/src/main/java/com/patentsight/config/SecurityConfig.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,6 +38,9 @@ public class SecurityConfig {
     @Value("${security.jwt.secret}")
     private String jwtSecret;
 
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -46,7 +50,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:5173"));
+        configuration.setAllowedOrigins(allowedOrigins);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setAllowCredentials(true);

--- a/backend/src/main/java/com/patentsight/global/config/WebConfig.java
+++ b/backend/src/main/java/com/patentsight/global/config/WebConfig.java
@@ -1,12 +1,18 @@
 package com.patentsight.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
 public class WebConfig {
+
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {
@@ -14,7 +20,7 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**") // 모든 경로 허용
-                        .allowedOrigins("*") // 모든 도메인 허용
+                        .allowedOrigins(allowedOrigins.toArray(new String[0]))
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*");
             }

--- a/backend/src/main/java/com/patentsight/user/controller/UserController.java
+++ b/backend/src/main/java/com/patentsight/user/controller/UserController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-@CrossOrigin(origins = {"http://35.175.253.22:3000", "http://35.175.253.22:3001"})  // CORS설정 추가(나성원)
 public class UserController {
 
     private final UserService userService;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,3 +24,10 @@ security:
     secret: "change-this-to-your-256-bit-secret_______________________"
   # 선택: 유효기간(ms). JwtTokenProvider에서 @Value로 쓰거나 하드코딩해도 됨
   jwt-validity-ms: 86400000
+
+cors:
+  allowed-origins:
+    - http://35.175.253.22
+    - http://35.175.253.22:3000
+    - http://35.175.253.22:3001
+    - http://localhost:5173


### PR DESCRIPTION
## Summary
- configure CORS origins via `cors.allowed-origins` property
- remove controller level `@CrossOrigin`
- apply shared origins to Spring Web config

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_68a27179e57083208f3b693ef20ac8ce