### PR TITLE
fix: adjust axios base URL to avoid duplicate /api

### DIFF
--- a/frontend/examiner_fe/src/api/auth.js
+++ b/frontend/examiner_fe/src/api/auth.js
@@ -4,7 +4,7 @@ import axios from './axiosInstance';
 export const loginUser = async ({ username, password }) => {
   try {
     console.log('심사관 로그인 요청 데이터:', { username, password });
-    const response = await axios.post('/users/login', { username, password });
+    const response = await axios.post('/api/users/login', { username, password });
     console.log('심사관 로그인 성공 응답:', response.data);
     return response.data;
   } catch (error) {
@@ -48,7 +48,7 @@ export const signupExaminer = async ({ username, password, name, birthDate, depa
   try {
     console.log('심사관 회원가입 요청 데이터:', { username, password, name, birthDate, department, employeeNumber, position });
     
-    const response = await axios.post('/users/examiner', {
+    const response = await axios.post('/api/users/examiner', {
       username,
       password,
       name,
@@ -93,7 +93,7 @@ export const verifyExaminerCode = async ({ authCode }) => {
   try {
     console.log('심사관 인증 코드 검증 요청:', { authCode });
     
-    const response = await axios.post('/users/verify-code', {
+    const response = await axios.post('/api/users/verify-code', {
       authCode,
     });
     console.log('심사관 인증 코드 검증 성공 응답:', response.data);

--- a/frontend/examiner_fe/src/api/axiosInstance.js
+++ b/frontend/examiner_fe/src/api/axiosInstance.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 
 // 필요하면 .env에서 덮어쓸 수 있게
 // .env.development / .env.production 에서 VITE_API_BASE_URL=/api 로 두는 걸 권장
-// ※ /api는 nginx에서 백엔드 프록시 경로이므로, API 호출 함수에서는 /api를 또 쓰지 않도록 주의!
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+// 기본값을 ''으로 두고 각 API 함수에서 '/api/...'를 명시해 중복 방지
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 /**
  * 배포가 서브 경로(/applicant, /examiner)인 경우를 위해
@@ -22,7 +22,7 @@ const BASENAME =
   : '';
 
 const axiosInstance = axios.create({
-  baseURL: API_BASE_URL, // 여기서 이미 '/api' 붙음 → API 함수에서는 '/users/...'처럼 작성
+  baseURL: API_BASE_URL, // 기본값 '' → API 함수에서 '/api/...' 전체 경로 작성
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',

--- a/frontend/examiner_fe/src/api/patent.js
+++ b/frontend/examiner_fe/src/api/patent.js
@@ -5,69 +5,69 @@ import axiosInstance from './axiosInstance';
 
 // 출원 생성
 export const createPatent = async (requestData) => {
-  // POST /api/patents
+  // POST /patents
   const response = await axiosInstance.post('/api/patents', requestData);
   return response.data;
 };
 
 // 출원 상세 정보 조회
 export const getPatentDetail = async (patentId) => {
-  // GET /api/patents/{id}
+  // GET /patents/{id}
   const response = await axiosInstance.get(`/api/patents/${patentId}`);
   return response.data;
 };
 
 // 내 출원 목록 조회
 export const getMyPatents = async () => {
-  // GET /api/patents/my
+  // GET /patents/my
   const response = await axiosInstance.get('/api/patents/my');
   return response.data;
 };
 
 // 출원 최종 제출
 export const submitPatent = async (patentId) => {
-  // POST /api/patents/{id}/submit
+  // POST /patents/{id}/submit
   const response = await axiosInstance.post(`/api/patents/${patentId}/submit`);
   return response.data;
 };
 
 // 출원 상태 업데이트
 export const updatePatentStatus = async (patentId, status) => {
-  // PATCH /api/patents/{id}/status
+  // PATCH /patents/{id}/status
   const response = await axiosInstance.patch(`/api/patents/${patentId}/status`, status);
   return response.data;
 };
 
 // 출원 문서 버전 목록 조회
 export const getDocumentVersions = async (patentId) => {
-  // GET /api/patents/{id}/document-versions
+  // GET /patents/{id}/document-versions
   const response = await axiosInstance.get(`/api/patents/${patentId}/document-versions`);
   return response.data;
 };
 
 // 최신 문서 내용 조회
 export const getLatestDocument = async (patentId) => {
-  // GET /api/patents/{id}/document/latest
+  // GET /patents/{id}/document/latest
   const response = await axiosInstance.get(`/api/patents/${patentId}/document/latest`);
   return response.data;
 };
 
 // 문서 내용 단순 수정
 export const updateDocumentContent = async (patentId, documentContent) => {
-  // PATCH /api/patents/{id}/document
+  // PATCH /patents/{id}/document
   const response = await axiosInstance.patch(`/api/patents/${patentId}/document`, documentContent);
   return response.data;
 };
 
 // 새 문서 버전 생성
 export const createDocumentVersion = async (patentId, requestData) => {
-  // POST /api/patents/{id}/document-versions
+  // POST /patents/{id}/document-versions
   const response = await axiosInstance.post(`/api/patents/${patentId}/document-versions`, requestData);
   return response.data;
 };
 
 // 출원 삭제
 export const deletePatent = async (patentId) => {
-  // DELETE /api/patents/{id}
+  // DELETE /patents/{id}
   await axiosInstance.delete(`/api/patents/${patentId}`);
 };


### PR DESCRIPTION
## Summary
- default axios base URL is now empty to avoid double `/api` prefix
- updated examiner API modules to call `/api/...` endpoints explicitly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a277303dbc8320836b91e176783675