### PR TITLE
Add examiner verification endpoint

### DIFF
--- a/backend/src/main/java/com/patentsight/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/patentsight/backend/controller/AuthController.java
@@ -1,0 +1,34 @@
+package com.patentsight.backend.controller;
+
+import com.patentsight.backend.service.AuthService;
+import com.patentsight.backend.service.AuthService.VerificationResult;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/examiner")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<Void> verify(@RequestBody Map<String, String> body) {
+        String code = body.get("code");
+        VerificationResult result = authService.verify(code);
+        return switch (result) {
+            case SUCCESS -> ResponseEntity.ok().build();
+            case FORBIDDEN -> ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            default -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        };
+    }
+}

--- a/backend/src/main/java/com/patentsight/backend/service/AuthService.java
+++ b/backend/src/main/java/com/patentsight/backend/service/AuthService.java
@@ -1,0 +1,51 @@
+package com.patentsight.backend.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+public class AuthService {
+
+    public enum VerificationResult {
+        SUCCESS,
+        UNAUTHORIZED,
+        FORBIDDEN
+    }
+
+    private final RestTemplate restTemplate;
+    private final String verificationUrl;
+
+    public AuthService(RestTemplateBuilder restTemplateBuilder,
+                       @Value("${auth.verification-url}") String verificationUrl) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.verificationUrl = verificationUrl;
+    }
+
+    public VerificationResult verify(String code) {
+        try {
+            ResponseEntity<Void> response = restTemplate.postForEntity(
+                    verificationUrl, Map.of("code", code), Void.class);
+            HttpStatus status = response.getStatusCode();
+            if (status.is2xxSuccessful()) {
+                return VerificationResult.SUCCESS;
+            } else if (status == HttpStatus.FORBIDDEN) {
+                return VerificationResult.FORBIDDEN;
+            } else {
+                return VerificationResult.UNAUTHORIZED;
+            }
+        } catch (HttpClientErrorException e) {
+            HttpStatus status = e.getStatusCode();
+            if (status == HttpStatus.FORBIDDEN) {
+                return VerificationResult.FORBIDDEN;
+            }
+            return VerificationResult.UNAUTHORIZED;
+        }
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=backend
+auth.verification-url=http://localhost:8081/api/verify

--- a/backend/src/test/java/com/patentsight/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/patentsight/backend/controller/AuthControllerTest.java
@@ -1,0 +1,57 @@
+package com.patentsight.backend.controller;
+
+import com.patentsight.backend.service.AuthService;
+import com.patentsight.backend.service.AuthService.VerificationResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void verifySuccess() throws Exception {
+        when(authService.verify("good"))
+                .thenReturn(VerificationResult.SUCCESS);
+
+        mockMvc.perform(post("/api/examiner/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"code\":\"good\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void verifyUnauthorized() throws Exception {
+        when(authService.verify("bad"))
+                .thenReturn(VerificationResult.UNAUTHORIZED);
+
+        mockMvc.perform(post("/api/examiner/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"code\":\"bad\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void verifyForbidden() throws Exception {
+        when(authService.verify("forbidden"))
+                .thenReturn(VerificationResult.FORBIDDEN);
+
+        mockMvc.perform(post("/api/examiner/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"code\":\"forbidden\"}"))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthController for POST /api/examiner/verify
- implement AuthService calling configurable verification URL
- cover controller success, unauthorized, and forbidden responses

## Testing
- `./gradlew test` *(fails: Cannot find Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_68a27e64eb7883209f9144594d653946