### PR TITLE
Handle empty body for patent submission

### DIFF
--- a/frontend/applicant_fe/package-lock.json
+++ b/frontend/applicant_fe/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.11.0",
+        "globals": "^16.3.0",
         "lucide-react": "^0.536.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2726,6 +2727,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
+      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {

--- a/frontend/applicant_fe/package.json
+++ b/frontend/applicant_fe/package.json
@@ -11,17 +11,18 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",
+    "@testing-library/jest-dom": "^6.6.4",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^13.5.0",
     "axios": "^1.11.0",
+    "globals": "^16.3.0",
     "lucide-react": "^0.536.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.7.1",
     "styled-components": "^6.1.19",
-    "zustand": "^4.5.4",
-    "@testing-library/jest-dom": "^6.6.4",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "^5.84.1",

--- a/frontend/applicant_fe/src/api/notifications.js
+++ b/frontend/applicant_fe/src/api/notifications.js
@@ -1,9 +1,11 @@
 import axios from './axiosInstance';
 
 // 알림 목록 조회
-export const getNotifications = async () => {
+export const getNotifications = async (userId) => {
   try {
-    const response = await axios.get('/api/notifications');
+    const response = await axios.get('/api/notifications', {
+      params: { userId },
+    });
     return response.data;
   } catch (error) {
     console.error('알림 목록 조회 실패:', error);
@@ -12,9 +14,11 @@ export const getNotifications = async () => {
 };
 
 // 미확인 알림 조회
-export const getUnreadNotifications = async () => {
+export const getUnreadNotifications = async (userId) => {
   try {
-    const response = await axios.get('/api/notifications/unread');
+    const response = await axios.get('/api/notifications/unread', {
+      params: { userId },
+    });
     return response.data;
   } catch (error) {
     console.error('미확인 알림 조회 실패:', error);

--- a/frontend/applicant_fe/src/api/patents.js
+++ b/frontend/applicant_fe/src/api/patents.js
@@ -4,7 +4,7 @@ import { AxiosError } from 'axios';
 import axios from './axiosInstance';
 
 // 각 함수를 async/await와 try...catch로 감싸 에러 핸들링을 추가합니다.
-export const createPatent = async (patentData) => {
+export const createPatent = async (patentData = {}) => {
   try {
     const res = await axios.post('/api/patents', patentData);
     return res.data; // { patentId, ... } 를 반환
@@ -36,7 +36,7 @@ export const updateFileContent = async (fileId, content) => {
 
 export const submitPatent = async (patentId) => {
   try {
-    const res = await axios.post(`/api/patents/${patentId}/submit`);
+    const res = await axios.post(`/api/patents/${patentId}/submit`, {});
     return res.data;
   } catch (error) {
     console.error('최종 제출 실패:', error);

--- a/frontend/applicant_fe/src/data/notifications.js
+++ b/frontend/applicant_fe/src/data/notifications.js
@@ -1,5 +1,8 @@
 // 알림 데이터 관리 (API 연동 + Fallback)
-import { getNotifications as fetchNotifications, getUnreadNotifications as fetchUnreadNotifications } from '../api/notifications';
+import {
+  getNotifications as fetchNotifications,
+  getUnreadNotifications as fetchUnreadNotifications,
+} from '../api/notifications';
 
 // Fallback 데이터 (API 실패 시 사용)
 const fallbackNotifications = [
@@ -46,9 +49,9 @@ const transformNotification = (notification) => {
 };
 
 // 알림 목록 조회 (API 우선, 실패 시 Fallback)
-export const getNotifications = async () => {
+export const getNotifications = async (userId) => {
   try {
-    const response = await fetchNotifications();
+    const response = await fetchNotifications(userId);
     return response.map(transformNotification);
   } catch (error) {
     console.warn('API 호출 실패, Fallback 데이터 사용:', error);
@@ -57,13 +60,13 @@ export const getNotifications = async () => {
 };
 
 // 미확인 알림 개수 조회
-export const getUnreadCount = async () => {
+export const getUnreadCount = async (userId) => {
   try {
-    const response = await fetchUnreadNotifications();
+    const response = await fetchUnreadNotifications(userId);
     return response.length;
   } catch (error) {
     console.warn('미확인 알림 API 호출 실패, Fallback 데이터 사용:', error);
-    return fallbackNotifications.filter(notification => !notification.is_read).length;
+    return fallbackNotifications.filter((notification) => !notification.is_read).length;
   }
 };
 
@@ -85,19 +88,17 @@ export const markAsRead = async (notificationId) => {
 };
 
 // 모든 알림 읽음 처리
-export const markAllAsRead = async () => {
+export const markAllAsRead = async (userId) => {
   try {
-    const notifications = await getNotifications();
-    const unreadNotifications = notifications.filter(n => !n.read);
-    
+    const notifications = await getNotifications(userId);
+    const unreadNotifications = notifications.filter((n) => !n.read);
+
     // 모든 미확인 알림을 읽음 처리
-    await Promise.all(
-      unreadNotifications.map(notification => markAsRead(notification.id))
-    );
+    await Promise.all(unreadNotifications.map((notification) => markAsRead(notification.id)));
   } catch (error) {
     console.warn('모든 알림 읽음 처리 실패:', error);
     // Fallback: 로컬에서 모든 알림을 읽음 처리
-    fallbackNotifications.forEach(notification => {
+    fallbackNotifications.forEach((notification) => {
       notification.is_read = true;
     });
   }

--- a/frontend/applicant_fe/src/pages/MyPage.jsx
+++ b/frontend/applicant_fe/src/pages/MyPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getMyPatents } from '../api/patents';
@@ -13,6 +13,7 @@ import {
   Bell
 } from 'lucide-react';
 import { getNotifications } from '../data/notifications';
+import useAuthStore from '../stores/authStore';
 
 // 병합된 컴포넌트들을 import 합니다.
 import SearchNavLink from '../components/SearchNavLink';
@@ -20,6 +21,7 @@ import PatentListModal from '../components/PatentListModal';
 
 const MyPage = () => {
   const navigate = useNavigate();
+  const { user } = useAuthStore();
   const [notifications, setNotifications] = useState([]);
   const [isLoadingNotifications, setIsLoadingNotifications] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -54,14 +56,10 @@ const MyPage = () => {
   const error = null;
 
   // 알림 데이터 로드
-  useEffect(() => {
-    loadNotifications();
-  }, []);
-
-  const loadNotifications = async () => {
+  const loadNotifications = useCallback(async () => {
     setIsLoadingNotifications(true);
     try {
-      const notificationData = await getNotifications();
+      const notificationData = await getNotifications(user?.id);
       setNotifications(notificationData);
     } catch (error) {
       console.error('알림 데이터 로드 실패:', error);
@@ -69,7 +67,11 @@ const MyPage = () => {
     } finally {
       setIsLoadingNotifications(false);
     }
-  };
+  }, [user?.id]);
+
+  useEffect(() => {
+    loadNotifications();
+  }, [loadNotifications]);
 
   const handleCardClick = (patentId) => {
     navigate(`/patent/${patentId}`);


### PR DESCRIPTION
## Summary
- Send an explicit empty JSON body when submitting a patent so Spring doesn't receive `undefined`
- Catch FastAPI prediction failures and default to `N/A` IPC code so submissions still succeed
- Pass user ID to notification API calls and guard against undefined patent bodies

## Testing
- `npx eslint src/api/notifications.js src/data/notifications.js src/pages/MyPage.jsx src/components/Navigation.jsx src/api/patents.js`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 3 errors, 2 warnings in unrelated files)*
- `./gradlew test` *(fails: no Java 17 toolchain configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a2aeee66148320a713ab866e01d0c4