### PR TITLE
refactor: externalize api urls

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
@@ -6,6 +6,7 @@ import com.patentsight.ai.dto.ClaimDraftDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -26,7 +27,8 @@ public class ClaimDraftClient {
     @Qualifier("externalAiWebClient")
     private final WebClient webClient;
 
-    private static final String CLAIM_API_URL = "https://neil-gordon-georgia-thumbnail.trycloudflare.com/generate";
+    @Value("${ai.claim-draft.url}")
+    private String claimApiUrl;
 
     /**
      * 외부 청구항 생성 API 호출 후 raw JSON 응답을 반환한다.
@@ -39,7 +41,7 @@ public class ClaimDraftClient {
         }
 
         String response = webClient.post()
-                .uri(URI.create(CLAIM_API_URL + "?minimal=true&include_rag_meta=true&rag_format=meta"))
+                .uri(URI.create(claimApiUrl + "?minimal=true&include_rag_meta=true&rag_format=meta"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(body)
                 .retrieve()

--- a/backend/src/main/java/com/patentsight/ai/util/DraftApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/DraftApiClient.java
@@ -2,6 +2,7 @@ package com.patentsight.ai.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -17,13 +18,14 @@ public class DraftApiClient {
 
     private final WebClient webClient;
 
-    private final String FASTAPI_URL = "http://13.236.174.54:8000/analyze/";
+    @Value("${ai.draft.url}")
+    private String fastapiUrl;
 
     public String requestOpinion(File file) {
         FileSystemResource resource = new FileSystemResource(file);
 
         return webClient.post()
-                .uri(FASTAPI_URL)
+                .uri(fastapiUrl)
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData("file", resource))
                 .retrieve()

--- a/backend/src/main/java/com/patentsight/ai/util/SearchApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/SearchApiClient.java
@@ -2,6 +2,7 @@ package com.patentsight.ai.util;
 
 import com.patentsight.ai.dto.ImageSearchResponse; // <-- 1. DTO 이름 변경됨
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -15,14 +16,16 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class SearchApiClient {
 
     private final WebClient webClient;
-    private final String FASTAPI_BASE_URL = "http://43.201.66.246:8000";
+
+    @Value("${ai.search.base-url}")
+    private String fastapiBaseUrl;
 
     /**
      * 이미지로 상표를 검색하는 FastAPI를 호출합니다.
      */
     public ImageSearchResponse searchTrademarkByImage(MultipartFile file) { // <-- 2. 반환 타입 변경됨
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/trademark/image")
+                .uri(fastapiBaseUrl + "/search/trademark/image")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData("file", file.getResource()))
                 .retrieve()
@@ -38,7 +41,7 @@ public class SearchApiClient {
         formData.add("text", text);
 
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/trademark/text")
+                .uri(fastapiBaseUrl + "/search/trademark/text")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(formData))
                 .retrieve()
@@ -51,7 +54,7 @@ public class SearchApiClient {
      */
     public ImageSearchResponse searchDesignByImage(MultipartFile file) { // <-- 2. 반환 타입 변경됨
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/design/image")
+                .uri(fastapiBaseUrl + "/search/design/image")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData("file", file.getResource()))
                 .retrieve()
@@ -67,7 +70,7 @@ public class SearchApiClient {
         formData.add("text", text);
 
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/design/text")
+                .uri(fastapiBaseUrl + "/search/design/text")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(formData))
                 .retrieve()

--- a/backend/src/main/java/com/patentsight/ai/util/SimilarSearchApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/SimilarSearchApiClient.java
@@ -1,5 +1,6 @@
 package com.patentsight.ai.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,15 +16,15 @@ import java.time.Duration;
 @Component
 public class SimilarSearchApiClient {
 
-    /** ✅ 여기서 주소를 직접 관리 */
-    private static final String BASE_URL    = "http://127.0.0.1:8000"; // FastAPI 서버
     private static final String SEARCH_PATH = "/search";               // 엔드포인트
     private static final long   TIMEOUT_MS  = 5000;
 
-    /** WebClient 생성 */
-    private final WebClient webClient = WebClient.builder()
-            .baseUrl(BASE_URL)
-            .build();
+    private final WebClient webClient;
+
+    public SimilarSearchApiClient(WebClient.Builder builder,
+                                  @Value("${ai.similar-search.base-url}") String baseUrl) {
+        this.webClient = builder.baseUrl(baseUrl).build();
+    }
 
     /**
      * 텍스트 질의로 유사 특허 검색

--- a/backend/src/main/java/com/patentsight/ai/util/ThreeDModelApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ThreeDModelApiClient.java
@@ -26,7 +26,7 @@ public class ThreeDModelApiClient {
     private final Path saveDir;
 
     public ThreeDModelApiClient(RestTemplate restTemplate,
-                                @Value("${ai.3d-model.endpoint:https://4731cfc6a89a.ngrok-free.app/generate}") String endpoint,
+                                @Value("${ai.3d-model.endpoint}") String endpoint,
                                 @Value("${ai.3d-model.save-dir:uploads}") String saveDir) {
         this.restTemplate = restTemplate;
         this.endpoint = endpoint;

--- a/backend/src/main/java/com/patentsight/ai/util/ValidationApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ValidationApiClient.java
@@ -3,6 +3,7 @@ package com.patentsight.ai.util;
 import com.patentsight.ai.dto.AiCheckRequest;
 import com.patentsight.ai.dto.AiCheckResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -12,12 +13,14 @@ import reactor.core.publisher.Mono;
 public class ValidationApiClient {
 
     private final WebClient webClient;
-    private final String VALIDATION_API_URL = "http://3.26.101.212:8000/api/ai/validations";
+
+    @Value("${ai.validation.url}")
+    private String validationApiUrl;
 
     public AiCheckResponse requestValidation(AiCheckRequest requestDto) {
         try {
             return webClient.post()
-                    .uri(VALIDATION_API_URL)
+                    .uri(validationApiUrl)
                     .body(Mono.just(requestDto), AiCheckRequest.class)
                     .retrieve()
                     .bodyToMono(AiCheckResponse.class) // 다시 DTO로 바로 받도록 수정

--- a/backend/src/main/java/com/patentsight/config/SecurityConfig.java
+++ b/backend/src/main/java/com/patentsight/config/SecurityConfig.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,6 +38,9 @@ public class SecurityConfig {
     @Value("${security.jwt.secret}")
     private String jwtSecret;
 
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -46,19 +50,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(
-            "http://35.175.253.22",
-            "http://35.175.253.22:3000",
-            "http://35.175.253.22:3001",
-            "http://35.175.253.22:3002",
-            "http://35.175.253.22:3003",
-            "http://35.175.253.22:5173",
-            "http://localhost:5173",
-            "http://localhost:3000",
-            "http://localhost:3001",
-            "http://localhost:3002",
-            "http://localhost:3003"
-        ));
+        configuration.setAllowedOrigins(allowedOrigins);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setAllowCredentials(true);

--- a/backend/src/main/java/com/patentsight/patent/service/PatentService.java
+++ b/backend/src/main/java/com/patentsight/patent/service/PatentService.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 // ✅ [알림] 추가 import
 import com.patentsight.notification.service.NotificationService;
 import com.patentsight.notification.dto.NotificationRequest;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -48,7 +49,9 @@ public class PatentService {
     private final SpecVersionRepository specVersionRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RestTemplate restTemplate; // RestTemplate 필드 추가
-    private final String fastApiIpcUrl = "http://127.0.0.1:5000/predict"; // AI 모델 IPC 엔드포인트
+
+    @Value("${ai.ipc.url}")
+    private String fastApiIpcUrl; // AI 모델 IPC 엔드포인트
 
     // ✅ [알림] 서비스 필드 추가
     private final NotificationService notificationService;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,3 +41,20 @@ cors:
     - http://localhost:3001
     - http://localhost:3002
     - http://localhost:3003
+
+ai:
+  search:
+    base-url: http://43.201.66.246:8000
+  similar-search:
+    base-url: http://127.0.0.1:8000
+  validation:
+    url: http://3.26.101.212:8000/api/ai/validations
+  claim-draft:
+    url: https://neil-gordon-georgia-thumbnail.trycloudflare.com/generate
+  draft:
+    url: http://13.236.174.54:8000/analyze/
+  ipc:
+    url: http://127.0.0.1:5000/predict
+  3d-model:
+    endpoint: https://4731cfc6a89a.ngrok-free.app/generate
+    save-dir: uploads


### PR DESCRIPTION
## Summary
- move external API endpoints into application.yml and inject via @Value
- load CORS allowed origins from configuration

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':test')*

------
https://chatgpt.com/codex/tasks/task_e_68a2c10a42288320b19e09643c72bef6