### PR TITLE
Add deploy script and integrate into backend CD

### DIFF
--- a/.github/workflows/cd-backend-ec2.yml
+++ b/.github/workflows/cd-backend-ec2.yml
@@ -1,8 +1,9 @@
+---
 name: CD backend → EC2 (CICD)
 
-on:
+'on':
   push:
-    branches: [ "CICD" ]          # CICD 브랜치에 푸시될 때만
+    branches: ["CICD"]          # CICD 브랜치에 푸시될 때만
     paths:
       - "backend/**"              # backend 변경시에만 트리거
   workflow_dispatch:               # 수동 실행 버튼
@@ -52,6 +53,26 @@ jobs:
           script: |
             mkdir -p /home/${{ secrets.USERNAME }}/app/releases
 
+      # 배포 스크립트 업로드 및 실행 권한 부여
+      - name: Upload deploy script to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.KEY }}
+          source: backend/deploy.sh
+          target: /home/${{ secrets.USERNAME }}/app/
+          strip_components: 1
+          overwrite: true
+
+      - name: Make deploy.sh executable on EC2
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.KEY }}
+          script: chmod +x /home/${{ secrets.USERNAME }}/app/deploy.sh
+
       # JAR 업로드: 상위 폴더(backend/build/libs)를 제거하고 파일만 떨어뜨림
       - name: Upload JAR to EC2
         uses: appleboy/scp-action@v0.1.7
@@ -59,7 +80,7 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
-          source: ${{ steps.findjar.outputs.jar }}    # ex) backend/build/libs/*.jar
+          source: ${{ steps.findjar.outputs.jar }}  # backend/build/libs/*.jar
           target: /home/${{ secrets.USERNAME }}/app/releases/
           strip_components: 3                          # ★ backend/build/libs 제거
           overwrite: true
@@ -73,7 +94,8 @@ jobs:
           key: ${{ secrets.KEY }}
           script: |
             ls -la /home/${{ secrets.USERNAME }}/app/releases
-            find /home/${{ secrets.USERNAME }}/app/releases -maxdepth 3 -type f -name "*.jar" -print
+            find /home/${{ secrets.USERNAME }}/app/releases \
+              -maxdepth 3 -type f -name "*.jar" -print
 
       # 서비스 재시작: 절대경로 하드코딩 + 최신 JAR 선택
       - name: Restart service on EC2
@@ -92,4 +114,5 @@ jobs:
             fi
             "$APP_DIR"/deploy.sh "$LATEST_JAR"
             sleep 2
-            curl -fsS "http://127.0.0.1:${APP_PORT:-8080}/actuator/health" || curl -fsS "http://127.0.0.1:${APP_PORT:-8080}" || true
+            curl -fsS "http://127.0.0.1:${APP_PORT:-8080}/actuator/health" || \
+            curl -fsS "http://127.0.0.1:${APP_PORT:-8080}" || true

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+JAR_PATH="$1"
+if [ -z "$JAR_PATH" ]; then
+  echo "Usage: $0 <jar-path>"
+  exit 1
+fi
+
+APP_DIR=$(dirname "$JAR_PATH")
+JAR_NAME=$(basename "$JAR_PATH")
+
+echo "Deploying $JAR_NAME"
+
+PID=$(pgrep -f "$JAR_NAME" || true)
+if [ -n "$PID" ]; then
+  echo "Stopping existing process $PID"
+  kill "$PID"
+  sleep 2
+fi
+
+nohup java -jar "$JAR_PATH" > "$APP_DIR/app.log" 2>&1 &
+
+echo "Started $JAR_NAME"
+


### PR DESCRIPTION
## Summary
- add backend/deploy.sh to stop old jar and launch new one
- update backend CD workflow to upload deploy.sh and make it executable on EC2

## Testing
- `yamllint .github/workflows/cd-backend-ec2.yml`
- `shellcheck backend/deploy.sh`
- `./gradlew test` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ce82bf148320968879aeb47b963a