### PR TITLE
Add default CORS configuration

### DIFF
--- a/backend/src/main/java/com/patentsight/config/SecurityConfig.java
+++ b/backend/src/main/java/com/patentsight/config/SecurityConfig.java
@@ -23,9 +23,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -38,8 +37,14 @@ public class SecurityConfig {
     @Value("${security.jwt.secret}")
     private String jwtSecret;
 
-    @Value("${cors.allowed-origins}")
+    @Value("${cors.allowed-origins:*}")
     private List<String> allowedOrigins;
+
+    @Value("${cors.allowed-methods:GET,POST,PUT,DELETE,OPTIONS}")
+    private List<String> allowedMethods;
+
+    @Value("${cors.allowed-headers:*}")
+    private List<String> allowedHeaders;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -51,8 +56,8 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(allowedOrigins);
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Collections.singletonList("*"));
+        configuration.setAllowedMethods(allowedMethods);
+        configuration.setAllowedHeaders(allowedHeaders);
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,6 +41,8 @@ cors:
     - http://localhost:3001
     - http://localhost:3002
     - http://localhost:3003
+  allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
+  allowed-headers: "*"
 
 ai:
   search:


### PR DESCRIPTION
## Summary
- default CORS origin/method/header values to prevent startup failures
- expose configurable CORS methods and headers in application.yml

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 bash gradlew test` *(fails: Could not resolve org.projectlombok:lombok:1.18.38; java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a2daa125dc83208b66b13d2508be5c