### PR TITLE
Refactor CORS configuration into properties bean

### DIFF
--- a/backend/src/main/java/com/patentsight/config/CorsProperties.java
+++ b/backend/src/main/java/com/patentsight/config/CorsProperties.java
@@ -1,0 +1,58 @@
+package com.patentsight.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configuration properties for CORS settings.
+ */
+@Component
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+
+    /**
+     * Origins allowed to access the backend. Defaults to "*".
+     */
+    private List<String> allowedOrigins = new ArrayList<>(Collections.singletonList("*"));
+
+    /**
+     * HTTP methods permitted for cross origin requests.
+     */
+    private List<String> allowedMethods = new ArrayList<>(
+            Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"));
+
+    /**
+     * Headers allowed in cross origin requests.
+     */
+    private List<String> allowedHeaders = new ArrayList<>(Collections.singletonList("*"));
+
+    public List<String> getAllowedOrigins() {
+        return allowedOrigins;
+    }
+
+    public void setAllowedOrigins(List<String> allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
+    public List<String> getAllowedMethods() {
+        return allowedMethods;
+    }
+
+    public void setAllowedMethods(List<String> allowedMethods) {
+        this.allowedMethods = allowedMethods;
+    }
+
+    public List<String> getAllowedHeaders() {
+        return allowedHeaders;
+    }
+
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
+    }
+}
+

--- a/backend/src/main/java/com/patentsight/config/SecurityConfig.java
+++ b/backend/src/main/java/com/patentsight/config/SecurityConfig.java
@@ -25,7 +25,6 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,14 +36,11 @@ public class SecurityConfig {
     @Value("${security.jwt.secret}")
     private String jwtSecret;
 
-    @Value("${cors.allowed-origins:*}")
-    private List<String> allowedOrigins;
+    private final CorsProperties corsProperties;
 
-    @Value("${cors.allowed-methods:GET,POST,PUT,DELETE,OPTIONS}")
-    private List<String> allowedMethods;
-
-    @Value("${cors.allowed-headers:*}")
-    private List<String> allowedHeaders;
+    public SecurityConfig(CorsProperties corsProperties) {
+        this.corsProperties = corsProperties;
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -55,9 +51,9 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(allowedOrigins);
-        configuration.setAllowedMethods(allowedMethods);
-        configuration.setAllowedHeaders(allowedHeaders);
+        configuration.setAllowedOriginPatterns(corsProperties.getAllowedOrigins());
+        configuration.setAllowedMethods(corsProperties.getAllowedMethods());
+        configuration.setAllowedHeaders(corsProperties.getAllowedHeaders());
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,7 +41,7 @@ cors:
     - http://localhost:3001
     - http://localhost:3002
     - http://localhost:3003
-  allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
+  allowed-methods: "GET,POST,PUT,DELETE,PATCH,OPTIONS,HEAD"
   allowed-headers: "*"
 
 ai:


### PR DESCRIPTION
## Summary
- centralize CORS settings in `CorsProperties`
- inject `CorsProperties` in `SecurityConfig` and use allowed origin patterns
- add PATCH and HEAD to allowed CORS methods in `application.yml`

## Testing
- `bash ./gradlew test` *(fails: Could not determine the dependencies of task ':test'. Could not resolve all dependencies for configuration ':testRuntimeClasspath'. Failed to calculate the value of task ':compileTestJava' property 'javaCompiler'. Cannot find a Java installation on your machine (Linux 6.12.13 amd64) matching: {languageVersion=17, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. Toolchain download repositories have not been configured.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e26351d88320a79343c73a14bded