### PR TITLE
Expand CORS support

### DIFF
--- a/backend/src/main/java/com/patentsight/config/SecurityConfig.java
+++ b/backend/src/main/java/com/patentsight/config/SecurityConfig.java
@@ -46,19 +46,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(
-            "http://35.175.253.22",
-            "http://35.175.253.22:3000",
-            "http://35.175.253.22:3001",
-            "http://35.175.253.22:3002",
-            "http://35.175.253.22:3003",
-            "http://35.175.253.22:5173",
-            "http://localhost:5173",
-            "http://localhost:3000",
-            "http://localhost:3001",
-            "http://localhost:3002",
-            "http://localhost:3003"
-        ));
+        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## Summary
- allow all origins in CORS configuration so browsers receive Access-Control-Allow-Origin headers

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation; ca-certificates-java package error)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e667da6c8320a0588a22768dac16