### PR TITLE
Fix CORS policy to allow frontend origins

### DIFF
--- a/backend/src/main/java/com/patentsight/config/SecurityConfig.java
+++ b/backend/src/main/java/com/patentsight/config/SecurityConfig.java
@@ -15,11 +15,10 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -44,18 +43,17 @@ public class SecurityConfig {
 
     // CORS
     @Bean
-
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(false);
-        config.addAllowedOriginPattern("*");
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("http://35.175.253.22:3001");
+        config.addAllowedOrigin("http://35.175.253.22:3000");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;
-
     }
 
     // JWT → 권한 매핑 (role/roles 클레임을 ROLE_* 권한으로)


### PR DESCRIPTION
## Summary
- enable CORS credentials and allow frontend origins in security configuration

## Testing
- `bash gradlew clean bootJar -x test`


------
https://chatgpt.com/codex/tasks/task_e_68a2effe0c6c8320a4ece3a007cdbd9c