### PR TITLE
Use setAllowedOrigins for CORS

### DIFF
--- a/backend/src/main/java/com/patentsight/config/CorsConfig.java
+++ b/backend/src/main/java/com/patentsight/config/CorsConfig.java
@@ -25,7 +25,7 @@ public class CorsConfig {
     private CorsConfiguration buildConfig() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOriginPatterns(ALLOWED_ORIGINS);
+        config.setAllowedOrigins(ALLOWED_ORIGINS);
         config.setAllowedHeaders(List.of("*"));
         config.setAllowedMethods(List.of("*"));
         return config;


### PR DESCRIPTION
## Summary
- replace deprecated `setAllowedOriginPatterns` with `setAllowedOrigins`
- verify allowed origin list includes required frontend URLs

## Testing
- `bash ./gradlew build -x test`
- `bash ./gradlew bootRun` *(fails: Bean named 'corsFilter' is expected to be of type 'org.springframework.web.filter.CorsFilter' but was actually of type 'org.springframework.boot.web.servlet.FilterRegistrationBean')*


------
https://chatgpt.com/codex/tasks/task_e_68a32028e9d48320a439398028b684f9