### PR TITLE
Remove controller-level CORS settings

### DIFF
--- a/backend/src/main/java/com/patentsight/config/CorsConfig.java
+++ b/backend/src/main/java/com/patentsight/config/CorsConfig.java
@@ -46,7 +46,7 @@ public class CorsConfig {
      * also return the necessary headers.
      */
     @Bean
-    public FilterRegistrationBean<CorsFilter> corsFilter() {
+    public FilterRegistrationBean<CorsFilter> corsFilterRegistration() {
         FilterRegistrationBean<CorsFilter> bean =
                 new FilterRegistrationBean<>(new CorsFilter(corsConfigurationSource()));
         bean.setOrder(Ordered.HIGHEST_PRECEDENCE);

--- a/backend/src/main/java/com/patentsight/user/controller/UserController.java
+++ b/backend/src/main/java/com/patentsight/user/controller/UserController.java
@@ -9,10 +9,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-@CrossOrigin(
-    origins = {"http://35.175.253.22:3000", "http://35.175.253.22:3001"},
-    allowCredentials = "true"
-)
 public class UserController {
 
     private final UserService userService;


### PR DESCRIPTION
## Summary
- remove `@CrossOrigin` from `UserController` to use global CORS configuration
- rename global CORS filter bean to avoid type conflicts

## Testing
- ❌ `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew build` (test compilation errors)
- ✅ `./gradlew build -x test`
- ✅ `curl -I -H "Origin: http://35.175.253.22:3000" -H "Access-Control-Request-Method: POST" -X OPTIONS http://localhost:8080/api/users/login`

------
https://chatgpt.com/codex/tasks/task_e_68a3225d1b5c832081437796161d3e82