### PR TITLE
docs: comment CORS origin configuration

### DIFF
--- a/backend/src/main/java/com/patentsight/config/CorsConfig.java
+++ b/backend/src/main/java/com/patentsight/config/CorsConfig.java
@@ -25,6 +25,8 @@ public class CorsConfig {
     private CorsConfiguration buildConfig() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
+        // Explicitly list allowed origins instead of patterns to ensure
+        // Access-Control-Allow-Origin returns the exact origin.
         config.setAllowedOrigins(ALLOWED_ORIGINS);
         config.setAllowedHeaders(List.of("*"));
         config.setAllowedMethods(List.of("*"));


### PR DESCRIPTION
## Summary
- document why `setAllowedOrigins` is used in CORS config

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':test' - Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68a32b42b620832098de4c2eafd2d54c