### PR TITLE
refactor: externalize CORS origins and rely on global config

### DIFF
--- a/backend/src/main/java/com/patentsight/config/CorsConfig.java
+++ b/backend/src/main/java/com/patentsight/config/CorsConfig.java
@@ -1,6 +1,7 @@
 package com.patentsight.config;
 
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,13 +20,13 @@ import java.util.List;
 @Configuration
 public class CorsConfig {
 
-    private static final List<String> ALLOWED_ORIGINS =
-            List.of("http://35.175.253.22:3000", "http://35.175.253.22:3001");
+    @Value("${cors.allowed-origins}")
+    private List<String> allowedOrigins;
 
     private CorsConfiguration buildConfig() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(ALLOWED_ORIGINS);
+        config.setAllowedOrigins(allowedOrigins);
         config.setAllowedHeaders(List.of(
             "Authorization",
             "Cache-Control",

--- a/backend/src/main/java/com/patentsight/user/controller/UserController.java
+++ b/backend/src/main/java/com/patentsight/user/controller/UserController.java
@@ -10,11 +10,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 
-@CrossOrigin(
-    origins = {"http://35.175.253.22:3000", "http://35.175.253.22:3001"},
-    allowCredentials = "true"
-)
-
 public class UserController {
 
     private final UserService userService;


### PR DESCRIPTION
## Summary
- inject CORS allowed origins from `application.yml` instead of hardcoding them
- rely solely on global CORS configuration by removing controller-level `@CrossOrigin`

## Testing
- `./gradlew build` *(fails: NotificationServiceTest and PatentServiceTest compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae22981883208dae2364683a6bb4