### PR TITLE
test: update notification service test for new impl

### DIFF
--- a/backend/src/test/java/com/patentsight/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/patentsight/notification/service/NotificationServiceTest.java
@@ -3,11 +3,11 @@ package com.patentsight.notification.service;
 import com.patentsight.notification.domain.Notification;
 import com.patentsight.notification.dto.NotificationResponse;
 import com.patentsight.notification.repository.NotificationRepository;
+import com.patentsight.notification.service.impl.NotificationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,44 +25,40 @@ class NotificationServiceTest {
     @Mock
     private NotificationRepository notificationRepository;
 
-    @InjectMocks
-    private NotificationService notificationService;
+    private NotificationServiceImpl notificationService;
 
     @BeforeEach
     void setup() {
-        notificationService = new NotificationService(notificationRepository);
+        notificationService = new NotificationServiceImpl(notificationRepository);
     }
 
     @Test
-    void listNotifications_returnsResponses() {
+    void getNotifications_returnsResponses() {
         Notification n = new Notification();
         n.setNotificationId(1L);
-        n.setUserId(1L);
         n.setNotificationType("TYPE");
         n.setMessage("msg");
         n.setTargetType("PATENT");
         n.setTargetId(2L);
         n.setRead(false);
         n.setCreatedAt(LocalDateTime.now());
-        when(notificationRepository.findByUserIdOrderByCreatedAtDesc(1L))
+        when(notificationRepository.findByUser_UserId(1L))
                 .thenReturn(Collections.singletonList(n));
 
-        List<NotificationResponse> list = notificationService.listNotifications(1L);
+        List<NotificationResponse> list = notificationService.getNotifications(1L);
         assertEquals(1, list.size());
         assertEquals(1L, list.get(0).getNotificationId());
     }
 
     @Test
-    void markRead_updatesEntity() {
+    void markAsRead_updatesEntity() {
         Notification n = new Notification();
         n.setNotificationId(1L);
         n.setRead(false);
         when(notificationRepository.findById(1L)).thenReturn(Optional.of(n));
-        when(notificationRepository.save(any(Notification.class))).thenAnswer(i -> i.getArgument(0));
 
-        boolean result = notificationService.markRead(1L, true);
+        notificationService.markAsRead(1L);
 
-        assertTrue(result);
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
         assertTrue(captor.getValue().isRead());
@@ -70,13 +66,8 @@ class NotificationServiceTest {
 
     @Test
     void deleteNotification_removesRecord() {
-        Notification n = new Notification();
-        n.setNotificationId(1L);
-        when(notificationRepository.findById(1L)).thenReturn(Optional.of(n));
+        notificationService.deleteNotification(1L);
 
-        boolean deleted = notificationService.deleteNotification(1L);
-
-        assertTrue(deleted);
-        verify(notificationRepository).delete(n);
+        verify(notificationRepository).deleteById(1L);
     }
 }


### PR DESCRIPTION
## Summary
- adjust notification service test to target `NotificationServiceImpl`
- update tests for renamed service methods and void operations

## Testing
- `bash gradlew test` *(fails: Could not determine the dependencies of task ':test'. Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b28e4eb083209095451198755cbf