### PR TITLE
feat: centralize external API configuration

### DIFF
--- a/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ClaimDraftClient.java
@@ -6,6 +6,7 @@ import com.patentsight.ai.dto.ClaimDraftDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -26,7 +27,8 @@ public class ClaimDraftClient {
     @Qualifier("externalAiWebClient")
     private final WebClient webClient;
 
-    private static final String CLAIM_API_URL = "https://neil-gordon-georgia-thumbnail.trycloudflare.com/generate";
+    @Value("${external-api.claim-url}")
+    private String claimApiUrl;
 
     /**
      * 외부 청구항 생성 API 호출 후 raw JSON 응답을 반환한다.
@@ -39,7 +41,7 @@ public class ClaimDraftClient {
         }
 
         String response = webClient.post()
-                .uri(URI.create(CLAIM_API_URL + "?minimal=true&include_rag_meta=true&rag_format=meta"))
+                .uri(URI.create(claimApiUrl + "?minimal=true&include_rag_meta=true&rag_format=meta"))
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(body)
                 .retrieve()

--- a/backend/src/main/java/com/patentsight/ai/util/DraftApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/DraftApiClient.java
@@ -2,6 +2,7 @@ package com.patentsight.ai.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -17,13 +18,14 @@ public class DraftApiClient {
 
     private final WebClient webClient;
 
-    private final String FASTAPI_URL = "http://13.236.174.54:8000/analyze/";
+    @Value("${external-api.draft-url}")
+    private String fastapiUrl;
 
     public String requestOpinion(File file) {
         FileSystemResource resource = new FileSystemResource(file);
 
         return webClient.post()
-                .uri(FASTAPI_URL)
+                .uri(fastapiUrl)
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData("file", resource))
                 .retrieve()

--- a/backend/src/main/java/com/patentsight/ai/util/SearchApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/SearchApiClient.java
@@ -2,6 +2,7 @@ package com.patentsight.ai.util;
 
 import com.patentsight.ai.dto.ImageSearchResponse; // <-- 1. DTO 이름 변경됨
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -15,14 +16,16 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class SearchApiClient {
 
     private final WebClient webClient;
-    private final String FASTAPI_BASE_URL = "http://43.201.66.246:8000";
+
+    @Value("${external-api.search-base-url}")
+    private String fastapiBaseUrl;
 
     /**
      * 이미지로 상표를 검색하는 FastAPI를 호출합니다.
      */
     public ImageSearchResponse searchTrademarkByImage(MultipartFile file) { // <-- 2. 반환 타입 변경됨
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/trademark/image")
+                .uri(fastapiBaseUrl + "/search/trademark/image")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData("file", file.getResource()))
                 .retrieve()
@@ -38,7 +41,7 @@ public class SearchApiClient {
         formData.add("text", text);
 
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/trademark/text")
+                .uri(fastapiBaseUrl + "/search/trademark/text")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(formData))
                 .retrieve()
@@ -51,7 +54,7 @@ public class SearchApiClient {
      */
     public ImageSearchResponse searchDesignByImage(MultipartFile file) { // <-- 2. 반환 타입 변경됨
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/design/image")
+                .uri(fastapiBaseUrl + "/search/design/image")
                 .contentType(MediaType.MULTIPART_FORM_DATA)
                 .body(BodyInserters.fromMultipartData("file", file.getResource()))
                 .retrieve()
@@ -67,7 +70,7 @@ public class SearchApiClient {
         formData.add("text", text);
 
         return webClient.post()
-                .uri(FASTAPI_BASE_URL + "/search/design/text")
+                .uri(fastapiBaseUrl + "/search/design/text")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(BodyInserters.fromFormData(formData))
                 .retrieve()

--- a/backend/src/main/java/com/patentsight/ai/util/SimilarSearchApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/SimilarSearchApiClient.java
@@ -1,5 +1,6 @@
 package com.patentsight.ai.util;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -9,21 +10,23 @@ import java.time.Duration;
 
 /**
  * 유사 특허 검색 모델 서버(FastAPI)를 호출하는 클라이언트
- * - BASE_URL, SEARCH_PATH는 여기서 관리
+ * - SEARCH_PATH는 여기서 관리하고 기본 URL은 설정에서 주입
  * - GET /search?query=...&top_n=... 형태로 요청
  */
 @Component
 public class SimilarSearchApiClient {
 
-    /** ✅ 여기서 주소를 직접 관리 */
-    private static final String BASE_URL    = "http://127.0.0.1:8000"; // FastAPI 서버
     private static final String SEARCH_PATH = "/search";               // 엔드포인트
     private static final long   TIMEOUT_MS  = 5000;
 
     /** WebClient 생성 */
-    private final WebClient webClient = WebClient.builder()
-            .baseUrl(BASE_URL)
-            .build();
+    private final WebClient webClient;
+
+    public SimilarSearchApiClient(@Value("${external-api.similar-search-base-url}") String baseUrl) {
+        this.webClient = WebClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
 
     /**
      * 텍스트 질의로 유사 특허 검색

--- a/backend/src/main/java/com/patentsight/ai/util/ThreeDModelApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ThreeDModelApiClient.java
@@ -26,7 +26,7 @@ public class ThreeDModelApiClient {
     private final Path saveDir;
 
     public ThreeDModelApiClient(RestTemplate restTemplate,
-                                @Value("${ai.3d-model.endpoint:https://4731cfc6a89a.ngrok-free.app/generate}") String endpoint,
+                                @Value("${external-api.three-d-model-endpoint:https://4731cfc6a89a.ngrok-free.app/generate}") String endpoint,
                                 @Value("${ai.3d-model.save-dir:uploads}") String saveDir) {
         this.restTemplate = restTemplate;
         this.endpoint = endpoint;

--- a/backend/src/main/java/com/patentsight/ai/util/ValidationApiClient.java
+++ b/backend/src/main/java/com/patentsight/ai/util/ValidationApiClient.java
@@ -3,6 +3,7 @@ package com.patentsight.ai.util;
 import com.patentsight.ai.dto.AiCheckRequest;
 import com.patentsight.ai.dto.AiCheckResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -12,12 +13,14 @@ import reactor.core.publisher.Mono;
 public class ValidationApiClient {
 
     private final WebClient webClient;
-    private final String VALIDATION_API_URL = "http://3.26.101.212:8000/api/ai/validations";
+
+    @Value("${external-api.validation-url}")
+    private String validationApiUrl;
 
     public AiCheckResponse requestValidation(AiCheckRequest requestDto) {
         try {
             return webClient.post()
-                    .uri(VALIDATION_API_URL)
+                    .uri(validationApiUrl)
                     .body(Mono.just(requestDto), AiCheckRequest.class)
                     .retrieve()
                     .bodyToMono(AiCheckResponse.class) // 다시 DTO로 바로 받도록 수정

--- a/backend/src/main/java/com/patentsight/patent/service/PatentService.java
+++ b/backend/src/main/java/com/patentsight/patent/service/PatentService.java
@@ -19,6 +19,7 @@ import com.patentsight.patent.dto.SubmitPatentResponse; // 새로 추가된 DTO
 import com.patentsight.ai.dto.PredictRequest; // 추가
 import com.patentsight.ai.dto.PredictResponse; // 추가
 import com.patentsight.patent.repository.PatentRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate; // RestTemplate 추가
@@ -42,7 +43,9 @@ public class PatentService {
     private final SpecVersionRepository specVersionRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RestTemplate restTemplate; // RestTemplate 필드 추가
-    private final String fastApiIpcUrl = "http://127.0.0.1:5000/predict"; // AI 모델 IPC 엔드포인트
+
+    @Value("${external-api.fastapi-ipc-url}")
+    private String fastApiIpcUrl; // AI 모델 IPC 엔드포인트
 
     // ✅ [알림] 서비스 필드 추가
     private final NotificationService notificationService;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,3 +41,13 @@ cors:
     - http://localhost:3001
     - http://localhost:3002
     - http://localhost:3003
+
+# 외부 API 엔드포인트를 한 곳에서 관리
+external-api:
+  fastapi-ipc-url: "http://127.0.0.1:5000/predict"
+  draft-url: "http://13.236.174.54:8000/analyze/"
+  search-base-url: "http://43.201.66.246:8000"
+  validation-url: "http://3.26.101.212:8000/api/ai/validations"
+  claim-url: "https://neil-gordon-georgia-thumbnail.trycloudflare.com/generate"
+  similar-search-base-url: "http://127.0.0.1:8000"
+  three-d-model-endpoint: "https://4731cfc6a89a.ngrok-free.app/generate"


### PR DESCRIPTION
## Summary
- centralize external API endpoints in `application.yml`
- inject external API URLs via `@Value` instead of hardcoded constants

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies due to missing trust store)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d9fe0a308320a1a5d8abc67fa9dc