### PR TITLE
Ensure JJWT implementation jars are on classpath

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,9 +35,9 @@ dependencies {
         // ✅ Spring Security + JWT
         implementation 'org.springframework.boot:spring-boot-starter-security'
         implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-        runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-        runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+        implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+        implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+        implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
         // Needed for MockMultipartFile
         implementation 'org.springframework:spring-test'


### PR DESCRIPTION
## Summary
- Ensure JJWT runtime modules (`jjwt-impl`, `jjwt-jackson`) are on compile classpath to provide `io.jsonwebtoken.io.Serializer` implementation.

## Testing
- `./gradlew build` *(fails: Cannot find a Java installation matching {languageVersion=17, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false})*

------
https://chatgpt.com/codex/tasks/task_e_68a3dfac1db48320b319b81c0816443e