### PR TITLE
Use MySQL driver for backend

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,8 +42,9 @@ dependencies {
         // Needed for MockMultipartFile
         implementation 'org.springframework:spring-test'
 
-	// ✅ DB
-	runtimeOnly 'com.h2database:h2'
+        // ✅ DB
+        // runtimeOnly 'com.h2database:h2'
+        runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// ✅ Lombok
 	compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## Summary
- replace in-memory H2 database with MySQL connector

## Testing
- `./gradlew clean build -x test`
- `./gradlew bootRun -x test` *(fails: Communications link failure)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ff26c5dc8320809c04b172737e9d