### PR TITLE
feat: structure claim draft output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/patent_workflow/README.md
+++ b/patent_workflow/README.md
@@ -1,0 +1,59 @@
+# Patent Workflow Service
+
+This directory contains a Python + LangGraph workflow for patent processing.
+
+## Features
+- Natural language query input with automatic intent & role detection
+- Parallel API passthrough, document review, similarity search and claim drafting
+- Review and search steps execute only when requested in the query
+- Role-based claim revision for applicants and rejection reason drafting for examiners
+- FastAPI server exposing a `/run` endpoint
+
+## Usage
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the server:
+   ```bash
+   uvicorn patent_workflow.api:app --reload
+   ```
+3. Send a request with a natural-language query:
+   ```bash
+   # Applicant requesting review, search and claim revision
+   curl -X POST http://localhost:8000/run -H 'Content-Type: application/json' \
+     -d '{"query": "출원인: 문서 검토하고 유사 특허 검색 후 수정해줘"}'
+
+   # Examiner requesting similarity search and rejection reasons
+   curl -X POST http://localhost:8000/run -H 'Content-Type: application/json' \
+     -d '{"query": "심사관: 유사 특허 검색하고 거절 사유 알려줘"}'
+   ```
+
+## Claim draft format
+
+The workflow returns structured claim drafts with metadata:
+
+```json
+{
+  "claim_draft": {
+    "log_id": "1",
+    "rag_context": "context",
+    "title": "Sample Title",
+    "summary": "Sample summary",
+    "technicalField": "tech field",
+    "backgroundTechnology": "background",
+    "inventionDetails": "details",
+    "claims": [
+      "claim 1",
+      "claim 2"
+    ]
+  }
+}
+```
+
+## Tests
+Run the test suite with:
+```bash
+pytest patent_workflow/tests
+```
+

--- a/patent_workflow/__init__.py
+++ b/patent_workflow/__init__.py
@@ -1,0 +1,2 @@
+"""Patent workflow package."""
+

--- a/patent_workflow/api.py
+++ b/patent_workflow/api.py
@@ -1,0 +1,16 @@
+"""FastAPI server exposing the workflow."""
+from fastapi import FastAPI
+
+from .schema import WorkflowInput, WorkflowOutput
+from .workflow import build_workflow
+
+app = FastAPI()
+workflow = build_workflow()
+
+
+@app.post("/run", response_model=WorkflowOutput, response_model_exclude_none=True)
+async def run_workflow(payload: WorkflowInput) -> WorkflowOutput:
+    """Run the patent workflow and return aggregated results."""
+    result = workflow.invoke({"query": payload.query})
+    return WorkflowOutput(**result).model_dump(exclude_none=True)
+

--- a/patent_workflow/requirements.txt
+++ b/patent_workflow/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+langgraph
+pydantic
+pytest

--- a/patent_workflow/schema.py
+++ b/patent_workflow/schema.py
@@ -1,0 +1,34 @@
+"""Pydantic models for workflow input and output."""
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class WorkflowInput(BaseModel):
+    """Input schema for the workflow."""
+    query: str
+
+
+class ClaimDraft(BaseModel):
+    """Structured draft object returned from claim drafting."""
+
+    log_id: Optional[str] = None
+    rag_context: Optional[str] = None
+    title: Optional[str] = None
+    summary: Optional[str] = None
+    technicalField: Optional[str] = None
+    backgroundTechnology: Optional[str] = None
+    inventionDetails: Optional[str] = None
+    claims: List[str]
+
+
+class WorkflowOutput(BaseModel):
+    """Aggregated workflow results."""
+
+    api_result: Optional[str] = None
+    review_result: Optional[str] = None
+    similar_patents: Optional[List[str]] = None
+    claim_draft: Optional[ClaimDraft] = None
+    revised_claim: Optional[str] = None
+    rejection_reason: Optional[str] = None
+    summary: str
+

--- a/patent_workflow/tests/test_api.py
+++ b/patent_workflow/tests/test_api.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+# Ensure root path is importable
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from patent_workflow.api import app
+
+
+def test_applicant_flow():
+    client = TestClient(app)
+    resp = client.post(
+        "/run",
+        json={"query": "출원인: 문서 검토하고 유사 특허 검색 후 수정해줘"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"] == "Workflow complete."
+    assert "review_result" in data
+    assert "similar_patents" in data
+    assert "claim_draft" in data and isinstance(data["claim_draft"].get("claims"), list)
+    assert "revised_claim" in data
+    assert "rejection_reason" not in data
+
+
+def test_examiner_flow():
+    client = TestClient(app)
+    resp = client.post(
+        "/run",
+        json={"query": "심사관: 유사 특허 검색하고 거절 사유 알려줘"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"] == "Workflow complete."
+    assert "rejection_reason" in data
+    assert "claim_draft" in data and isinstance(data["claim_draft"].get("claims"), list)
+    assert "review_result" not in data
+    assert "revised_claim" not in data

--- a/patent_workflow/tools.py
+++ b/patent_workflow/tools.py
@@ -1,0 +1,33 @@
+"""External API tool wrappers."""
+from __future__ import annotations
+import json
+from typing import List
+
+
+class KIPRISTool:
+    """Stub wrapper for KIPRIS patent search API."""
+
+    def search(self, query: str) -> List[str]:
+        # Placeholder implementation
+        return [f"Result for {query} 1", f"Result for {query} 2"]
+
+
+class GPTTool:
+    """Stub wrapper for GPT-based text generation."""
+
+    def generate(self, prompt: str) -> str:
+        # Placeholder implementation
+        if "Draft claim" in prompt:
+            sample = {
+                "log_id": "1",
+                "rag_context": "context",
+                "title": "Sample Title",
+                "summary": "Sample summary",
+                "technicalField": "tech field",
+                "backgroundTechnology": "background",
+                "inventionDetails": "details",
+                "claims": ["claim 1", "claim 2"],
+            }
+            return json.dumps(sample)
+        return f"Generated text based on: {prompt}"
+

--- a/patent_workflow/workflow.py
+++ b/patent_workflow/workflow.py
@@ -1,0 +1,148 @@
+"""LangGraph workflow definition."""
+from __future__ import annotations
+import json
+from typing import List, TypedDict
+
+from langgraph.graph import END, StateGraph
+
+from .tools import GPTTool, KIPRISTool
+from .schema import ClaimDraft
+
+
+class PatentState(TypedDict, total=False):
+    query: str
+    role: str
+    wants_revision: bool
+    needs_review: bool
+    needs_search: bool
+    api_result: str
+    review_result: str
+    similar_patents: List[str]
+    claim_draft: ClaimDraft
+    similarity: float
+    revised_claim: str
+    rejection_reason: str
+    summary: str
+
+
+def intent_router(state: PatentState) -> dict:
+    """Determine user intent and desired processing steps."""
+    q = state["query"]
+    lower = q.lower()
+    role = "examiner" if ("심사관" in q or "examiner" in lower) else "applicant"
+    wants_revision = any(k in q for k in ["수정", "거절"])
+    needs_review = any(k in q for k in ["검토", "오류", "형식"])
+    needs_search = any(k in q for k in ["유사", "검색"])
+    return {
+        "role": role,
+        "wants_revision": wants_revision,
+        "needs_review": needs_review,
+        "needs_search": needs_search,
+    }
+
+
+def api_passthrough(state: PatentState) -> dict:
+    return {"api_result": f"Echo: {state['query']}"}
+
+
+def document_review(state: PatentState) -> dict:
+    if not state.get("needs_review"):
+        return {}
+    return {"review_result": "No issues found."}
+
+
+def similar_patent_search(state: PatentState) -> dict:
+    if not state.get("needs_search"):
+        return {}
+    tool = KIPRISTool()
+    return {"similar_patents": tool.search(state["query"])}
+
+
+def claim_draft_generation(state: PatentState) -> dict:
+    tool = GPTTool()
+    raw = tool.generate(f"Draft claim for {state['query']}")
+    try:
+        data = json.loads(raw)
+    except Exception:
+        # Fallback structure if the tool does not return JSON
+        data = {
+            "log_id": None,
+            "rag_context": None,
+            "title": None,
+            "summary": raw,
+            "technicalField": None,
+            "backgroundTechnology": None,
+            "inventionDetails": None,
+            "claims": [raw],
+        }
+    return {"claim_draft": ClaimDraft(**data)}
+
+
+def compare_similarity(state: PatentState) -> dict:
+    # Dummy similarity computation
+    return {"similarity": 0.3}
+
+
+def route_by_role(state: PatentState) -> str:
+    similarity_low = state.get("similarity", 0) < 0.5
+    role = state.get("role")
+    wants_revision = state.get("wants_revision", False)
+    if similarity_low and wants_revision:
+        if role == "applicant":
+            return "revise"
+        if role == "examiner":
+            return "reject"
+    return "final"
+
+
+def revise_claim(state: PatentState) -> dict:
+    tool = GPTTool()
+    return {"revised_claim": tool.generate("Revise claim based on feedback")}
+
+
+def rejection_reason(state: PatentState) -> dict:
+    tool = GPTTool()
+    return {"rejection_reason": tool.generate("Potential rejection reasons")}
+
+
+def final_summary(state: PatentState) -> dict:
+    return {"summary": "Workflow complete."}
+
+
+def build_workflow():
+    """Compile and return the LangGraph workflow."""
+    graph = StateGraph(PatentState)
+
+    graph.add_node("intent_router", intent_router)
+    graph.add_node("api_passthrough", api_passthrough)
+    graph.add_node("document_review", document_review)
+    graph.add_node("similar_patent_search", similar_patent_search)
+    graph.add_node("claim_draft_generation", claim_draft_generation)
+    graph.add_node("compare_similarity", compare_similarity)
+    graph.add_node("revise_claim", revise_claim)
+    graph.add_node("rejection_reason", rejection_reason)
+    graph.add_node("finalize", final_summary)
+
+    graph.set_entry_point("intent_router")
+
+    # Parallel steps after intent routing
+    graph.add_edge("intent_router", "api_passthrough")
+    graph.add_edge("intent_router", "document_review")
+    graph.add_edge("intent_router", "similar_patent_search")
+    graph.add_edge("intent_router", "claim_draft_generation")
+
+    # Join parallel steps
+    graph.add_edge("api_passthrough", "compare_similarity")
+    graph.add_edge("document_review", "compare_similarity")
+    graph.add_edge("similar_patent_search", "compare_similarity")
+    graph.add_edge("claim_draft_generation", "compare_similarity")
+
+    # Conditional revision flow
+    graph.add_conditional_edges("compare_similarity", route_by_role, {"revise": "revise_claim", "reject": "rejection_reason", "final": "finalize"})
+    graph.add_edge("revise_claim", "finalize")
+    graph.add_edge("rejection_reason", "finalize")
+
+    graph.add_edge("finalize", END)
+
+    return graph.compile()
+


### PR DESCRIPTION
## Summary
- add ClaimDraft Pydantic model and wire into WorkflowOutput
- parse GPT claim draft into structured object within workflow
- test claim_draft structure and document expected format

## Testing
- `pytest patent_workflow/tests/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e6e522c48320ae8fc9b6a161b0fa