### PR TITLE
Remove redundant /api prefixes in examiner frontend APIs

### DIFF
--- a/frontend/examiner_fe/src/api/ai.js
+++ b/frontend/examiner_fe/src/api/ai.js
@@ -34,7 +34,7 @@ export const startChatSession = async (patentId, userId) => {
     async () => {
       const query = new URLSearchParams({ patentId: String(patentId) });
       if (userId != null) query.set('userId', String(userId));
-      const res = await axiosInstance.post(`/api/ai/chat/sessions?${query.toString()}`);
+      const res = await axiosInstance.post(`/ai/chat/sessions?${query.toString()}`);
       return res.data;
     },
     { id: crypto.randomUUID(), startedAt: new Date().toISOString(), status: 'ACTIVE', mock: true }
@@ -50,7 +50,7 @@ export const sendChatMessageToServer = async (sessionId, payload) => {
   };
   return swallow404(
     async () => {
-      const res = await axiosInstance.post(`/api/ai/chat/sessions/${sessionId}/messages`, body);
+      const res = await axiosInstance.post(`/ai/chat/sessions/${sessionId}/messages`, body);
       return res.data;
     },
     {
@@ -71,7 +71,7 @@ export const sendChatMessageToServer = async (sessionId, payload) => {
 export const validatePatentDocument = async (patentId) => {
   return swallow404(
     async () => {
-      const res = await axiosInstance.post(`/api/ai/patents/${encodeURIComponent(patentId)}/validate`);
+      const res = await axiosInstance.post(`/ai/patents/${encodeURIComponent(patentId)}/validate`);
       return res.data;
     },
     [] // 더미: 문제 없음
@@ -87,9 +87,9 @@ export const searchDesignImageByFile = async (file) => {
       const form = new FormData();
       form.append('file', file);
       const { data } = await axiosInstance.post(
-      '/api/ai/search/design/image',
-       form,
-       { headers: { 'Content-Type': 'multipart/form-data' } }
+        '/ai/search/design/image',
+        form,
+        { headers: { 'Content-Type': 'multipart/form-data' } }
       );
       return data;
     },
@@ -117,7 +117,7 @@ export const searchTrademarkImage = async (input) => {
     async () => {
       const form = new FormData();
       form.append('file', file);
-      const { data } = await axiosInstance.post('/api/ai/search/trademark/image', form, {
+      const { data } = await axiosInstance.post('/ai/search/trademark/image', form, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       return data;
@@ -170,7 +170,7 @@ export const generate3DModel = async (patentId, imageRef = {}) => {
   // imageRef: { image_id?: number, image_url?: string }
   return swallow404(
     async () => {
-      const res = await axiosInstance.post('/api/ai/3d-models', {
+      const res = await axiosInstance.post('/ai/3d-models', {
         patent_id: patentId,
         ...imageRef,
       });
@@ -186,7 +186,7 @@ export const generate3DModel = async (patentId, imageRef = {}) => {
 export const generateRejectionDraft = async (patentId, fileId) => {
   return swallow404(
     async () => {
-      const res = await axiosInstance.post('/api/ai/drafts/rejections', {
+      const res = await axiosInstance.post('/ai/drafts/rejections', {
         patentId, // 스펙 표기가 camelCase
         fileId,   // 선택값
       });

--- a/frontend/examiner_fe/src/api/auth.js
+++ b/frontend/examiner_fe/src/api/auth.js
@@ -4,7 +4,7 @@ import axios from './axiosInstance';
 export const loginUser = async ({ username, password }) => {
   try {
     console.log('심사관 로그인 요청 데이터:', { username, password });
-    const response = await axios.post('/api/users/login', { username, password });
+    const response = await axios.post('/users/login', { username, password });
     console.log('심사관 로그인 성공 응답:', response.data);
     return response.data;
   } catch (error) {
@@ -48,7 +48,7 @@ export const signupExaminer = async ({ username, password, name, birthDate, depa
   try {
     console.log('심사관 회원가입 요청 데이터:', { username, password, name, birthDate, department, employeeNumber, position });
     
-    const response = await axios.post('/api/users/examiner', {
+    const response = await axios.post('/users/examiner', {
       username,
       password,
       name,
@@ -93,7 +93,7 @@ export const verifyExaminerCode = async ({ authCode }) => {
   try {
     console.log('심사관 인증 코드 검증 요청:', { authCode });
     
-    const response = await axios.post('/api/users/verify-code', {
+    const response = await axios.post('/users/verify-code', {
       authCode,
     });
     console.log('심사관 인증 코드 검증 성공 응답:', response.data);

--- a/frontend/examiner_fe/src/api/files.js
+++ b/frontend/examiner_fe/src/api/files.js
@@ -1,7 +1,7 @@
 // src/api/files.js
 import axiosInstance from './axiosInstance';
 
-const API_ROOT = '/api/files';
+const API_ROOT = '/files';
 
 const isHttpUrl = (u) => /^https?:\/\//i.test(u);
 
@@ -16,6 +16,9 @@ export function toAbsoluteFileUrl(u) {
   // prod에선 절대 baseURL을 붙여주고, dev에선 프록시/동일오리진 가정
   if (base && isHttpUrl(base)) {
     return base.replace(/\/+$/, '') + normalized;
+  }
+  if (base) {
+    return `${base.replace(/\/+$/, '')}${normalized}`;
   }
   return normalized;
 }
@@ -49,7 +52,7 @@ export async function getImageUrlsByIds(fileIds = []) {
       if (primary) return toAbsoluteFileUrl(primary);
       if (m.patentId && m.fileName) {
         const enc = encodeURIComponent(m.fileName);
-        return toAbsoluteFileUrl(`/api/files/${m.patentId}/${enc}`);
+        return toAbsoluteFileUrl(`${API_ROOT}/${m.patentId}/${enc}`);
       }
       return '';
     })
@@ -65,7 +68,7 @@ export async function getNonImageFilesByIds(fileIds = []) {
     .map((m) => {
       const fallback =
         m.patentId && m.fileName
-          ? `/api/files/${m.patentId}/${encodeURIComponent(m.fileName)}`
+          ? `${API_ROOT}/${m.patentId}/${encodeURIComponent(m.fileName)}`
           : '';
       const url = toAbsoluteFileUrl(m.fileUrl || m.url || fallback);
       return url

--- a/frontend/examiner_fe/src/api/patent.js
+++ b/frontend/examiner_fe/src/api/patent.js
@@ -5,69 +5,69 @@ import axiosInstance from './axiosInstance';
 
 // 출원 생성
 export const createPatent = async (requestData) => {
-  // POST /api/patents
-  const response = await axiosInstance.post('/api/patents', requestData);
+  // POST /patents
+  const response = await axiosInstance.post('/patents', requestData);
   return response.data;
 };
 
 // 출원 상세 정보 조회
 export const getPatentDetail = async (patentId) => {
-  // GET /api/patents/{id}
-  const response = await axiosInstance.get(`/api/patents/${patentId}`);
+  // GET /patents/{id}
+  const response = await axiosInstance.get(`/patents/${patentId}`);
   return response.data;
 };
 
 // 내 출원 목록 조회
 export const getMyPatents = async () => {
-  // GET /api/patents/my
-  const response = await axiosInstance.get('/api/patents/my');
+  // GET /patents/my
+  const response = await axiosInstance.get('/patents/my');
   return response.data;
 };
 
 // 출원 최종 제출
 export const submitPatent = async (patentId) => {
-  // POST /api/patents/{id}/submit
-  const response = await axiosInstance.post(`/api/patents/${patentId}/submit`);
+  // POST /patents/{id}/submit
+  const response = await axiosInstance.post(`/patents/${patentId}/submit`);
   return response.data;
 };
 
 // 출원 상태 업데이트
 export const updatePatentStatus = async (patentId, status) => {
-  // PATCH /api/patents/{id}/status
-  const response = await axiosInstance.patch(`/api/patents/${patentId}/status`, status);
+  // PATCH /patents/{id}/status
+  const response = await axiosInstance.patch(`/patents/${patentId}/status`, status);
   return response.data;
 };
 
 // 출원 문서 버전 목록 조회
 export const getDocumentVersions = async (patentId) => {
-  // GET /api/patents/{id}/document-versions
-  const response = await axiosInstance.get(`/api/patents/${patentId}/document-versions`);
+  // GET /patents/{id}/document-versions
+  const response = await axiosInstance.get(`/patents/${patentId}/document-versions`);
   return response.data;
 };
 
 // 최신 문서 내용 조회
 export const getLatestDocument = async (patentId) => {
-  // GET /api/patents/{id}/document/latest
-  const response = await axiosInstance.get(`/api/patents/${patentId}/document/latest`);
+  // GET /patents/{id}/document/latest
+  const response = await axiosInstance.get(`/patents/${patentId}/document/latest`);
   return response.data;
 };
 
 // 문서 내용 단순 수정
 export const updateDocumentContent = async (patentId, documentContent) => {
-  // PATCH /api/patents/{id}/document
-  const response = await axiosInstance.patch(`/api/patents/${patentId}/document`, documentContent);
+  // PATCH /patents/{id}/document
+  const response = await axiosInstance.patch(`/patents/${patentId}/document`, documentContent);
   return response.data;
 };
 
 // 새 문서 버전 생성
 export const createDocumentVersion = async (patentId, requestData) => {
-  // POST /api/patents/{id}/document-versions
-  const response = await axiosInstance.post(`/api/patents/${patentId}/document-versions`, requestData);
+  // POST /patents/{id}/document-versions
+  const response = await axiosInstance.post(`/patents/${patentId}/document-versions`, requestData);
   return response.data;
 };
 
 // 출원 삭제
 export const deletePatent = async (patentId) => {
-  // DELETE /api/patents/{id}
-  await axiosInstance.delete(`/api/patents/${patentId}`);
+  // DELETE /patents/{id}
+  await axiosInstance.delete(`/patents/${patentId}`);
 };

--- a/frontend/examiner_fe/src/api/review.js
+++ b/frontend/examiner_fe/src/api/review.js
@@ -63,7 +63,7 @@ async function _listWithParams(userId, paramsCandidates) {
   let lastErr;
   for (const params of paramsCandidates) {
     try {
-      const { data } = await axiosInstance.get(`/api/reviews/list/${userId}`, {
+      const { data } = await axiosInstance.get(`/reviews/list/${userId}`, {
         params,
         validateStatus: okOrClientErr,
       });
@@ -80,7 +80,7 @@ async function _searchWithParams(examinerId, paramsCandidates) {
   let lastErr;
   for (const params of paramsCandidates) {
     try {
-      const { data } = await axiosInstance.get(`/api/reviews/search/${examinerId}`, {
+      const { data } = await axiosInstance.get(`/reviews/search/${examinerId}`, {
         params,
         validateStatus: okOrClientErr,
       });
@@ -97,7 +97,7 @@ async function _searchWithParams(examinerId, paramsCandidates) {
  * @param {object} requestData - { applicationNumber: number, examinerId: number }
  */
 export const assignReviewer = async (requestData) => {
-  const response = await axiosInstance.post('/api/reviews/assign', requestData);
+  const response = await axiosInstance.post('/reviews/assign', requestData);
   return response.data;
 };
 
@@ -106,7 +106,7 @@ export const assignReviewer = async (requestData) => {
  * @param {string} type - 'PATENT' | 'DESIGN'
  */
 export const autoAssign = async (type) => {
-  const response = await axiosInstance.post(`/api/reviews/assign/auto`, null, {
+  const response = await axiosInstance.post(`/reviews/assign/auto`, null, {
     params: { type },
   });
   return response.data;
@@ -136,7 +136,7 @@ export const getReviewList = async (userId, opts) => {
     }
     // ✅ 그 외는 status로 처리
     if (STATUS_SET.has(v)) {
-      const { data } = await axiosInstance.get(`/api/reviews/list/${userId}`, {
+      const { data } = await axiosInstance.get(`/reviews/list/${userId}`, {
         params: { status: v },
         validateStatus: okOrClientErr,
       });
@@ -163,7 +163,7 @@ export const getReviewList = async (userId, opts) => {
 
     // 타입이 없고 상태만 있는 경우
     if (status && STATUS_SET.has(status)) {
-      const { data } = await axiosInstance.get(`/api/reviews/list/${userId}`, {
+      const { data } = await axiosInstance.get(`/reviews/list/${userId}`, {
         params: { status },
         validateStatus: okOrClientErr,
       });
@@ -171,14 +171,14 @@ export const getReviewList = async (userId, opts) => {
     }
 
     // 필터 없음
-    const { data } = await axiosInstance.get(`/api/reviews/list/${userId}`, {
+    const { data } = await axiosInstance.get(`/reviews/list/${userId}`, {
       validateStatus: okOrClientErr,
     });
     return asArray(data);
   }
 
   // 파라미터가 아예 없으면 전체
-  const { data } = await axiosInstance.get(`/api/reviews/list/${userId}`, {
+  const { data } = await axiosInstance.get(`/reviews/list/${userId}`, {
     validateStatus: okOrClientErr,
   });
   return asArray(data);
@@ -188,7 +188,7 @@ export const getReviewList = async (userId, opts) => {
  * 4. 심사 상세 조회
  */
 export const getReviewDetail = async (reviewId) => {
-  const response = await axiosInstance.get(`/api/reviews/${reviewId}`, {
+  const response = await axiosInstance.get(`/reviews/${reviewId}`, {
     validateStatus: okOrClientErr,
   });
   return response.data; // 상세는 객체 그대로
@@ -199,7 +199,7 @@ export const getReviewDetail = async (reviewId) => {
  * @param {{ patentId:number, decision:string, comment:string }} requestData
  */
 export const submitReview = async (requestData) => {
-  const response = await axiosInstance.post('/api/reviews/submit', requestData);
+  const response = await axiosInstance.post('/reviews/submit', requestData);
   return response.data;
 };
 
@@ -208,7 +208,7 @@ export const submitReview = async (requestData) => {
  */
 export const createOpinionNotice = async (reviewId, requestData) => {
   const response = await axiosInstance.post(
-    `/api/reviews/${reviewId}/opinion-notices`,
+    `/reviews/${reviewId}/opinion-notices`,
     requestData
   );
   return response.data;
@@ -218,7 +218,7 @@ export const createOpinionNotice = async (reviewId, requestData) => {
  * 7. 의견서 목록 조회 (항상 배열)
  */
 export const getOpinionNotices = async (reviewId) => {
-  const { data } = await axiosInstance.get(`/api/reviews/${reviewId}/opinion-notices`, {
+  const { data } = await axiosInstance.get(`/reviews/${reviewId}/opinion-notices`, {
     validateStatus: okOrClientErr,
   });
   return asArray(data);
@@ -228,7 +228,7 @@ export const getOpinionNotices = async (reviewId) => {
  * 8. 심사 대시보드 요약 (항상 객체)
  */
 export const getDashboard = async (userId) => {
-  const { data } = await axiosInstance.get(`/api/reviews/dashboard/${userId}`, {
+  const { data } = await axiosInstance.get(`/reviews/dashboard/${userId}`, {
     validateStatus: okOrClientErr,
   });
   return asObject(data);
@@ -238,7 +238,7 @@ export const getDashboard = async (userId) => {
  * 9. 심사관 최근 활동 (항상 배열)
  */
 export const getRecentActivities = async () => {
-  const { data } = await axiosInstance.get('/api/reviews/recent-activities', {
+  const { data } = await axiosInstance.get('/reviews/recent-activities', {
     validateStatus: okOrClientErr,
   });
   return asArray(data);
@@ -252,7 +252,7 @@ export const getRecentActivities = async () => {
 export const searchReviews = async (examinerId, params = {}) => {
   const { type, ...rest } = params || {};
   if (!type) {
-    const { data } = await axiosInstance.get(`/api/reviews/search/${examinerId}`, {
+    const { data } = await axiosInstance.get(`/reviews/search/${examinerId}`, {
       params: rest,
       validateStatus: okOrClientErr,
     });
@@ -260,7 +260,7 @@ export const searchReviews = async (examinerId, params = {}) => {
   }
   const t = String(type).toUpperCase();
   if (!TYPE_SET.has(t)) {
-    const { data } = await axiosInstance.get(`/api/reviews/search/${examinerId}`, {
+    const { data } = await axiosInstance.get(`/reviews/search/${examinerId}`, {
       params,
       validateStatus: okOrClientErr,
     });


### PR DESCRIPTION
## Summary
- Drop leading `/api` from auth endpoints, matching axios base URL
- Strip `/api` from patent, AI, review, and file service calls to avoid duplicated path segments
- Enhance file URL helper to prepend axios base URL when needed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 12 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a421f6a8a48320b3966ce3032d056f