### PR TITLE
Improve error handling for file uploads

### DIFF
--- a/backend/src/main/java/com/patentsight/file/controller/FileController.java
+++ b/backend/src/main/java/com/patentsight/file/controller/FileController.java
@@ -2,7 +2,9 @@ package com.patentsight.file.controller;
 
 import com.patentsight.config.JwtTokenProvider;
 import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.service.FileService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,6 +56,12 @@ public class FileController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(S3UploadException.class)
+    public ResponseEntity<String> handleS3UploadException(S3UploadException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ex.getMessage());
     }
 }
 

--- a/backend/src/main/java/com/patentsight/file/exception/S3UploadException.java
+++ b/backend/src/main/java/com/patentsight/file/exception/S3UploadException.java
@@ -1,0 +1,14 @@
+package com.patentsight.file.exception;
+
+/**
+ * Exception thrown when a file cannot be uploaded or updated in the underlying
+ * storage such as AWS S3. The original error message is preserved to aid
+ * debugging of storage-related issues.
+ */
+public class S3UploadException extends RuntimeException {
+
+    public S3UploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/backend/src/main/java/com/patentsight/file/service/FileService.java
+++ b/backend/src/main/java/com/patentsight/file/service/FileService.java
@@ -2,6 +2,7 @@ package com.patentsight.file.service;
 
 import com.patentsight.file.domain.FileAttachment;
 import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.repository.FileRepository;
 import com.patentsight.global.util.FileUtil;
 import com.patentsight.patent.domain.Patent;
@@ -45,7 +46,7 @@ public class FileService {
             fileRepository.save(attachment);
             return toResponse(attachment);
         } catch (IOException e) {
-            throw new RuntimeException("Could not store file", e);
+            throw new S3UploadException("Could not store file: " + e.getMessage(), e);
         }
     }
 
@@ -68,7 +69,7 @@ public class FileService {
             fileRepository.save(attachment);
             return toResponse(attachment);
         } catch (IOException e) {
-            throw new RuntimeException("Could not update file", e);
+            throw new S3UploadException("Could not update file: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
## Summary
- propagate S3 upload failures using custom S3UploadException
- return HTTP 500 with detailed message when file uploads fail

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching 17)*

------
https://chatgpt.com/codex/tasks/task_e_68a5260a35388320bb4fb9ec6af20ae6