### PR TITLE
feat: track file type for attachments

### DIFF
--- a/backend/src/main/java/com/patentsight/file/domain/FileAttachment.java
+++ b/backend/src/main/java/com/patentsight/file/domain/FileAttachment.java
@@ -31,6 +31,9 @@ public class FileAttachment {
      */
     private String fileUrl;
 
+    @Enumerated(EnumType.STRING)
+    private FileType fileType;
+
     /**
      * All patent documents are stored as raw JSON text rather than as binary
      * files on disk. The content column keeps the latest text for the
@@ -52,6 +55,8 @@ public class FileAttachment {
     public void setFileName(String fileName) { this.fileName = fileName; }
     public String getFileUrl() { return fileUrl; }
     public void setFileUrl(String fileUrl) { this.fileUrl = fileUrl; }
+    public FileType getFileType() { return fileType; }
+    public void setFileType(FileType fileType) { this.fileType = fileType; }
     public String getContent() { return content; }
     public void setContent(String content) { this.content = content; }
     public LocalDateTime getUpdatedAt() { return updatedAt; }

--- a/backend/src/main/java/com/patentsight/file/domain/FileType.java
+++ b/backend/src/main/java/com/patentsight/file/domain/FileType.java
@@ -1,0 +1,7 @@
+package com.patentsight.file.domain;
+
+public enum FileType {
+    IMAGE,
+    GLB,
+    PDF
+}

--- a/backend/src/main/java/com/patentsight/file/dto/FileResponse.java
+++ b/backend/src/main/java/com/patentsight/file/dto/FileResponse.java
@@ -1,6 +1,7 @@
 package com.patentsight.file.dto;
 
 import java.time.LocalDateTime;
+import com.patentsight.file.domain.FileType;
 
 /**
  * Generic file metadata returned when creating or requesting a
@@ -14,6 +15,7 @@ public class FileResponse {
     private String fileUrl;
     private String content;
     private LocalDateTime updatedAt;
+    private FileType fileType;
 
     public Long getFileId() {
         return fileId;
@@ -69,5 +71,13 @@ public class FileResponse {
 
     public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public FileType getFileType() {
+        return fileType;
+    }
+
+    public void setFileType(FileType fileType) {
+        this.fileType = fileType;
     }
 }

--- a/backend/src/main/java/com/patentsight/file/service/FileService.java
+++ b/backend/src/main/java/com/patentsight/file/service/FileService.java
@@ -2,6 +2,7 @@ package com.patentsight.file.service;
 
 import com.patentsight.file.domain.FileAttachment;
 import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.domain.FileType;
 import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.repository.FileRepository;
 import com.patentsight.global.util.FileUtil;
@@ -37,6 +38,7 @@ public class FileService {
             attachment.setUploaderId(uploaderId);
             attachment.setFileName(file.getOriginalFilename());
             attachment.setFileUrl(path);
+            attachment.setFileType(determineFileType(file.getOriginalFilename()));
             attachment.setUpdatedAt(LocalDateTime.now());
 
             Patent patent = patentRepository.findById(patentId)
@@ -65,6 +67,7 @@ public class FileService {
             String path = FileUtil.saveFile(file);
             attachment.setFileName(file.getOriginalFilename());
             attachment.setFileUrl(path);
+            attachment.setFileType(determineFileType(file.getOriginalFilename()));
             attachment.setUpdatedAt(LocalDateTime.now());
             fileRepository.save(attachment);
             return toResponse(attachment);
@@ -91,9 +94,21 @@ public class FileService {
         res.setUploaderId(attachment.getUploaderId());
         res.setFileName(attachment.getFileName());
         res.setFileUrl(attachment.getFileUrl());
+        res.setFileType(attachment.getFileType());
         res.setContent(attachment.getContent());
         res.setUpdatedAt(attachment.getUpdatedAt());
         return res;
+    }
+
+    private FileType determineFileType(String name) {
+        if (name == null) return null;
+        String ext = name.contains(".") ? name.substring(name.lastIndexOf('.') + 1).toLowerCase() : "";
+        return switch (ext) {
+            case "png", "jpg", "jpeg", "gif", "bmp" -> FileType.IMAGE;
+            case "glb" -> FileType.GLB;
+            case "pdf" -> FileType.PDF;
+            default -> null;
+        };
     }
 
     public FileAttachment findById(Long id) {

--- a/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
+++ b/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
@@ -1,6 +1,7 @@
 package com.patentsight.file.service;
 
 import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.domain.FileType;
 import com.patentsight.file.dto.FileResponse;
 import com.patentsight.file.repository.FileRepository;
 import com.patentsight.global.util.FileUtil;
@@ -38,7 +39,7 @@ class FileServiceTest {
     @Test
     void createStoresFileAndReturnsMetadata() throws Exception {
         MockMultipartFile multipartFile = new MockMultipartFile(
-                "file", "hello.txt", "text/plain", "hello".getBytes());
+                "file", "hello.pdf", "application/pdf", "hello".getBytes());
 
         when(fileRepository.save(any(FileAttachment.class))).thenAnswer(invocation -> {
             FileAttachment att = invocation.getArgument(0);
@@ -56,7 +57,8 @@ class FileServiceTest {
         assertEquals(1L, res.getFileId());
         assertEquals(99L, res.getUploaderId());
         assertEquals(10L, res.getPatentId());
-        assertEquals("hello.txt", res.getFileName());
+        assertEquals("hello.pdf", res.getFileName());
+        assertEquals(FileType.PDF, res.getFileType());
         assertNotNull(res.getFileUrl());
         verify(fileRepository).save(any(FileAttachment.class));
 


### PR DESCRIPTION
## Summary
- add FileType enum with IMAGE, GLB, PDF
- store and expose fileType in FileAttachment and FileResponse
- classify uploaded files by extension in FileService
- update unit test for PDF detection

## Testing
- `./gradlew test` *(fails: cannot find symbol HttpMethod in SecurityConfig)*

------
https://chatgpt.com/codex/tasks/task_e_68a55076cae88320a7eeaeec300da4fc