### PR TITLE
fix: send document fields at top level

### DIFF
--- a/frontend/applicant_fe/src/api/patents.js
+++ b/frontend/applicant_fe/src/api/patents.js
@@ -157,9 +157,10 @@ export const sendMessageToChatSession = async (sessionId, message) => {
 // 문서 내용 수정(임시저장) API
 export const updateDocument = async ({ patentId, documentData }) => {
   try {
-    // ✅ 수정됨: documentData를 감싸서 보내야 백엔드에서 인식 가능
+    // 프론트에서 받은 documentData 내부 필드를 최상단으로 펼쳐서 전송합니다.
+    // 백엔드가 body.title 등을 직접 기대하므로, 중첩된 구조를 제거합니다.
     const res = await axios.patch(`/api/patents/${patentId}/document`, {
-      documentData,   // <-- 이 부분을 추가/수정
+      ...documentData,
     });
     return res.data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- fix updateDocument API to send document fields directly instead of nested under `documentData`

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint` *(fails: Cannot find package 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_68a55897fb808320842f22eddcc00b36