### PR TITLE
Prevent spec version failures from blocking patent saves

### DIFF
--- a/backend/src/main/java/com/patentsight/file/service/SpecVersionService.java
+++ b/backend/src/main/java/com/patentsight/file/service/SpecVersionService.java
@@ -1,0 +1,26 @@
+package com.patentsight.file.service;
+
+import com.patentsight.file.domain.SpecVersion;
+import com.patentsight.file.repository.SpecVersionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SpecVersionService {
+    private final SpecVersionRepository specVersionRepository;
+
+    public SpecVersionService(SpecVersionRepository specVersionRepository) {
+        this.specVersionRepository = specVersionRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(SpecVersion version) {
+        specVersionRepository.save(version);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveAll(Iterable<SpecVersion> versions) {
+        specVersionRepository.saveAll(versions);
+    }
+}


### PR DESCRIPTION
## Summary
- isolate spec version persistence in a new service using its own transaction
- guard patent creation from spec version save failures to ensure records reach the patent table

## Testing
- `PATH=/usr/bin:/bin ./gradlew test` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68a82d1e62808320bb292c851852b68d