### PR TITLE
Ensure sequential application numbers and resilient patent saves

### DIFF
--- a/backend/src/main/java/com/patentsight/file/service/SpecVersionService.java
+++ b/backend/src/main/java/com/patentsight/file/service/SpecVersionService.java
@@ -1,0 +1,26 @@
+package com.patentsight.file.service;
+
+import com.patentsight.file.domain.SpecVersion;
+import com.patentsight.file.repository.SpecVersionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SpecVersionService {
+    private final SpecVersionRepository specVersionRepository;
+
+    public SpecVersionService(SpecVersionRepository specVersionRepository) {
+        this.specVersionRepository = specVersionRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(SpecVersion version) {
+        specVersionRepository.save(version);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveAll(Iterable<SpecVersion> versions) {
+        specVersionRepository.saveAll(versions);
+    }
+}

--- a/backend/src/main/java/com/patentsight/patent/repository/PatentRepository.java
+++ b/backend/src/main/java/com/patentsight/patent/repository/PatentRepository.java
@@ -14,6 +14,9 @@ public interface PatentRepository extends JpaRepository<Patent, Long> {
 
     Optional<Patent> findByApplicationNumber(String applicationNumber);
 
+    @Query("select max(p.applicationNumber) from Patent p where p.applicationNumber like concat(:prefix, '%')")
+    String findMaxApplicationNumberWithPrefix(@Param("prefix") String prefix);
+
     // 🔹 전체 출원 단위로 미배정된 출원 조회
     @Query("""
         SELECT p FROM Patent p


### PR DESCRIPTION
## Summary
- derive next application number from existing records to assign sequential IDs
- wrap spec version persistence in try/catch so patent records persist even if version saves fail

## Testing
- `bash gradlew test` *(fails: Cannot find a Java installation on the machine)*

------
https://chatgpt.com/codex/tasks/task_e_68a82d1e62808320bb292c851852b68d