### PR TITLE
feat: add repository method for applicant patents

### DIFF
--- a/backend/src/main/java/com/patentsight/patent/repository/PatentRepository.java
+++ b/backend/src/main/java/com/patentsight/patent/repository/PatentRepository.java
@@ -30,4 +30,6 @@ public interface PatentRepository extends JpaRepository<Patent, Long> {
             @Param("type") PatentType type,
             @Param("status") PatentStatus status
     );
+
+    List<Patent> findByApplicantId(Long applicantId);
 }

--- a/backend/src/main/java/com/patentsight/patent/service/PatentService.java
+++ b/backend/src/main/java/com/patentsight/patent/service/PatentService.java
@@ -132,8 +132,7 @@ public class PatentService {
 
     @Transactional(readOnly = true)
     public List<PatentResponse> getMyPatents(Long applicantId) {
-        return patentRepository.findAll().stream()
-                .filter(p -> applicantId.equals(p.getApplicantId()))
+        return patentRepository.findByApplicantId(applicantId).stream()
                 .map(p -> toPatentResponse(p, null))
                 .collect(Collectors.toList());
     }

--- a/backend/src/test/java/com/patentsight/patent/service/PatentServiceTest.java
+++ b/backend/src/test/java/com/patentsight/patent/service/PatentServiceTest.java
@@ -212,7 +212,7 @@ class PatentServiceTest {
         patent.setTitle("T");
         patent.setType(PatentType.PATENT);
         patent.setStatus(PatentStatus.DRAFT);
-        when(patentRepository.findAll()).thenReturn(Collections.singletonList(patent));
+        when(patentRepository.findByApplicantId(1L)).thenReturn(Collections.singletonList(patent));
 
         FileAttachment file = new FileAttachment();
         file.setFileId(10L);

--- a/frontend/applicant_fe/src/pages/DocumentEditor.jsx
+++ b/frontend/applicant_fe/src/pages/DocumentEditor.jsx
@@ -84,8 +84,8 @@ const DocumentEditor = () => {
   const saveMutation = useMutation({
     mutationFn: updateDocument,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['myPatents'] });
-      queryClient.invalidateQueries({ queryKey: ['patentDocument', patentId] });
+      queryClient.invalidateQueries(['myPatents']);
+      queryClient.invalidateQueries(['patentDocument', patentId]);
       alert('임시저장이 완료되었습니다.');
     },
     onError: (error) => alert('저장 중 오류가 발생했습니다: ' + error.message),
@@ -101,7 +101,7 @@ const DocumentEditor = () => {
     },
     onSuccess: () => {
       // MyPage와 임시저장목록의 데이터를 모두 갱신하도록 신호를 보냅니다.
-      queryClient.invalidateQueries({ queryKey: ['myPatents'] });
+      queryClient.invalidateQueries(['myPatents']);
       alert('출원서가 최종 제출되었습니다. 마이페이지로 이동합니다.');
       navigate('/mypage'); 
     },

--- a/frontend/applicant_fe/src/pages/FinalSubmit.jsx
+++ b/frontend/applicant_fe/src/pages/FinalSubmit.jsx
@@ -20,7 +20,7 @@ const FinalSubmitPage = () => {
       alert(`최종 제출이 완료되었습니다. (출원번호: ${result.applicationNumber})`);
       
       // 이 한 줄만 있으면 됩니다. 마이페이지 데이터를 새로고침하라는 명령.
-      queryClient.invalidateQueries({ queryKey: ['myPatents'] });
+      queryClient.invalidateQueries(['myPatents']);
       
       navigate('/mypage');
     },

--- a/frontend/applicant_fe/src/pages/PatentDetail.jsx
+++ b/frontend/applicant_fe/src/pages/PatentDetail.jsx
@@ -6,9 +6,11 @@ import {
   updateFileContent,
   submitPatent
 } from '../api/patents';
+import { useQueryClient } from '@tanstack/react-query';
 
 const PatentDetail = () => {
   const { id } = useParams();
+  const queryClient = useQueryClient();
 
   const [patent, setPatent] = useState(null);
   const [fileContent, setFileContent] = useState('');
@@ -24,6 +26,7 @@ const PatentDetail = () => {
     try {
       const response = await submitPatent(id);
       setPatent((prev) => ({ ...prev, status: response.status }));
+      queryClient.invalidateQueries(['myPatents']);
       setSubmitStatus('✅ 제출 완료되었습니다.');
     } catch (err) {
       console.error('제출 실패:', err);
@@ -59,6 +62,7 @@ const PatentDetail = () => {
     setSaveStatus('');
     try {
       await updateFileContent(fileId, fileContent);
+      queryClient.invalidateQueries(['myPatents']);
       setSaveStatus('✅ 임시 저장 완료');
     } catch (err) {
       console.error('임시 저장 실패:', err);


### PR DESCRIPTION
## Summary
- expose PatentRepository#findByApplicantId
- streamline PatentService#getMyPatents to use repository lookup
- adjust tests for new repository method
- refresh patent lists after edits by invalidating `myPatents` query on save or submit

## Testing
- `./gradlew test` *(failed: Cannot find a Java installation matching 17)*
- `npm test` *(missing script: "test")*
- `npm run lint` *(failed: 8 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8345e905c8320b525e1f2e9f204d2