### PR TITLE
feat: add CloudWatch logging

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -56,6 +56,10 @@ dependencies {
         // AWS S3 client
         implementation 'software.amazon.awssdk:s3:2.25.12'
 
+        // AWS CloudWatch logging
+        implementation 'com.amazonaws:aws-java-sdk-logs:1.12.788'
+        implementation 'com.sndyuk:logback-more-appenders:1.8.8'
+
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -34,3 +34,12 @@ external-api:
   claim-url: "https://neil-gordon-georgia-thumbnail.trycloudflare.com/generate"
   similar-search-base-url: "http://127.0.0.1:8000"
   three-d-model-endpoint: "https://4731cfc6a89a.ngrok-free.app/generate"
+
+aws:
+  accessKeyId: ${AWS_ACCESS_KEY_ID:}
+  secretAccessKey: ${AWS_SECRET_ACCESS_KEY:}
+  region: ${AWS_REGION:us-east-1}
+
+logging:
+  cloudwatch:
+    log-group: ${CLOUDWATCH_LOG_GROUP:patentsight-log-group}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <springProperty scope="context" name="AWS_ACCESS_KEY_ID" source="aws.accessKeyId"/>
+    <springProperty scope="context" name="AWS_SECRET_ACCESS_KEY" source="aws.secretAccessKey"/>
+    <springProperty scope="context" name="AWS_REGION" source="aws.region"/>
+    <springProperty scope="context" name="LOG_GROUP" source="logging.cloudwatch.log-group"/>
+
+    <appender name="CLOUDWATCH" class="com.sndyuk.logback.more.appenders.CloudWatchAppender">
+        <logGroupName>${LOG_GROUP}</logGroupName>
+        <logStreamName>${HOSTNAME}</logStreamName>
+        <regionName>${AWS_REGION}</regionName>
+        <accessKeyId>${AWS_ACCESS_KEY_ID}</accessKeyId>
+        <secretAccessKey>${AWS_SECRET_ACCESS_KEY}</secretAccessKey>
+        <maxBatchSize>100</maxBatchSize>
+        <maxBatchTimeMillis>1000</maxBatchTimeMillis>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </layout>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="CLOUDWATCH"/>
+    </root>
+
+</configuration>
+


### PR DESCRIPTION
## Summary
- add AWS CloudWatch logging dependencies
- configure logback to send INFO+ logs to CloudWatch
- expose AWS credentials and log group settings in application.yml

## Testing
- `./gradlew test` *(fails: Compilation failed; see the compiler output)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b448da5083208da1e4ad53b5f66f