### PR TITLE
chore: version backend artifacts with git hash

### DIFF
--- a/.github/workflows/cd-backend-ec2.yml
+++ b/.github/workflows/cd-backend-ec2.yml
@@ -30,6 +30,10 @@ jobs:
         working-directory: backend
         run: chmod +x gradlew
 
+      - name: Get short Git hash
+        id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Build (Gradle bootJar)
         working-directory: backend
         # [수정] --refresh-dependencies 옵션을 추가하여 손상된 캐시를 무시하고 모든 라이브러리를 새로 받도록 강제합니다.
@@ -39,7 +43,11 @@ jobs:
         id: findjar
         shell: bash
         run: |
-          JAR=$(ls -t backend/build/libs/*.jar | head -n 1)
+          JAR="backend/build/libs/backend-0.0.1-${{ steps.vars.outputs.sha }}.jar"
+          if [ ! -f "$JAR" ]; then
+            echo "Jar not found: $JAR" >&2
+            exit 1
+          fi
           echo "jar=$JAR" >> $GITHUB_OUTPUT
           echo "Found JAR: $JAR"
 
@@ -72,18 +80,15 @@ jobs:
           script: |
             set -e
             APP_DIR="/home/${{ secrets.USERNAME }}/app"
-            
-            # releases 폴더에서 가장 최신 JAR 파일의 전체 경로를 찾습니다.
-            LATEST_JAR=$(ls -t "$APP_DIR"/releases/*.jar | head -n 1)
-            echo "Latest jar: $LATEST_JAR"
-            
-            # JAR 파일이 없는 경우 에러를 발생시키고 중단합니다.
-            if [ -z "$LATEST_JAR" ]; then
-              echo "ERROR: No jar found under $APP_DIR/releases"; exit 1
+            JAR_NAME=$(basename "${{ steps.findjar.outputs.jar }}")
+            TARGET_JAR="$APP_DIR/releases/$JAR_NAME"
+            echo "Deploying: $TARGET_JAR"
+
+            if [ ! -f "$TARGET_JAR" ]; then
+              echo "ERROR: $TARGET_JAR not found"; exit 1
             fi
-            
-            # deploy.sh 스크립트에 최신 JAR 파일 경로를 인자로 전달하여 실행합니다.
-            "$APP_DIR"/deploy.sh "$LATEST_JAR"
+
+            "$APP_DIR"/deploy.sh "$TARGET_JAR"
             
             # [수정] Health Check: Spring Security로 인해 actuator/health 접근 시 401 인증 오류가 발생하고,
             # 이로 인해 배포가 지연되거나 실패하는 것처럼 보이므로 해당 부분을 제거합니다.

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,8 +4,20 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
+import java.io.ByteArrayOutputStream
+
 group = 'com.patentsight'
-version = '0.0.1-SNAPSHOT'
+
+def gitHash() {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+version = "0.0.1-${gitHash()}"
 
 java {
 	toolchain {


### PR DESCRIPTION
## Summary
- derive backend jar version from short git hash
- deploy backend jar by exact git-hash name in CD workflow

## Testing
- `./gradlew clean bootJar -x test` *(fails: Could not determine the dependencies of task ':bootJar'. Cannot find a Java installation...)*

------
https://chatgpt.com/codex/tasks/task_e_68a9baee69d08320b0ca8dd3c63cf639