### PR TITLE
ci: deploy boot jar in backend CD workflow

### DIFF
--- a/.github/workflows/cd-backend-ec2.yml
+++ b/.github/workflows/cd-backend-ec2.yml
@@ -43,9 +43,9 @@ jobs:
         id: findjar
         shell: bash
         run: |
-          JAR="backend/build/libs/backend-0.0.1-${{ steps.vars.outputs.sha }}.jar"
-          if [ ! -f "$JAR" ]; then
-            echo "Jar not found: $JAR" >&2
+          JAR=$(find backend/build/libs -maxdepth 1 -name '*.jar' ! -name '*-plain.jar' | head -n 1)
+          if [ -z "$JAR" ]; then
+            echo "Jar not found" >&2
             exit 1
           fi
           echo "jar=$JAR" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- deploy executable Spring Boot JAR instead of *-plain.jar in backend CD workflow
- pick the freshly built JAR regardless of SNAPSHOT naming

## Testing
- `./backend/gradlew -p backend clean bootJar -x test --no-daemon --console=plain`
- `jar tf backend/build/libs/*.jar | grep logback-more-appenders`


------
https://chatgpt.com/codex/tasks/task_e_68a9bfc17ff8832085de85d94b01cd18