### PR TITLE
Remove CloudWatch logging and fix CD workflow JAR lookup

### DIFF
--- a/.github/workflows/cd-backend-ec2.yml
+++ b/.github/workflows/cd-backend-ec2.yml
@@ -43,7 +43,7 @@ jobs:
         id: findjar
         shell: bash
         run: |
-          JAR=$(ls -t backend/build/libs/*-SNAPSHOT.jar 2>/dev/null | grep -v plain | head -n 1)
+          JAR=$(ls -t backend/build/libs/*.jar 2>/dev/null | grep -v plain | head -n 1)
 
           if [ -z "$JAR" ]; then
             echo "Jar not found" >&2
@@ -90,9 +90,3 @@ jobs:
             fi
 
             "$APP_DIR"/deploy.sh "$TARGET_JAR"
-            
-            # [수정] Health Check: Spring Security로 인해 actuator/health 접근 시 401 인증 오류가 발생하고,
-            # 이로 인해 배포가 지연되거나 실패하는 것처럼 보이므로 해당 부분을 제거합니다.
-            # 배포 성공 여부는 EC2 서버 접속 또는 실제 서비스 접속으로 확인하는 것이 더 확실합니다.
-            # sleep 2
-            # curl -fsS "http://127.0.0.1:${APP_PORT:-8080}/actuator/health" || curl -fsS "http://127.0.0.1:${APP_PORT:-8080}" || true

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -68,10 +68,6 @@ dependencies {
         // AWS S3 client
         implementation 'software.amazon.awssdk:s3:2.25.12'
 
-        // AWS CloudWatch logging
-        implementation 'software.amazon.awssdk:cloudwatchlogs:2.25.12'
-        implementation 'com.sndyuk:logback-more-appenders:1.8.8'
-
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,7 +39,3 @@ aws:
   accessKeyId: ${AWS_ACCESS_KEY_ID:}
   secretAccessKey: ${AWS_SECRET_ACCESS_KEY:}
   region: ${AWS_REGION:us-east-1}
-
-logging:
-  cloudwatch:
-    log-group: ${CLOUDWATCH_LOG_GROUP:patentsight-log-group}

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,20 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-
-    <springProperty scope="context" name="AWS_REGION" source="aws.region"/>
-    <springProperty scope="context" name="LOG_GROUP" source="logging.cloudwatch.log-group"/>
-
-    <appender name="CLOUDWATCH" class="ch.qos.logback.more.appenders.CloudWatchLogbackAppenderV2">
-        <awsConfig>
-            <region>${AWS_REGION}</region>
-        </awsConfig>
-        <logGroupName>${LOG_GROUP}</logGroupName>
-        <logStreamName>${HOSTNAME}</logStreamName>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
@@ -23,8 +8,5 @@
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="CLOUDWATCH"/>
     </root>
-
 </configuration>
-


### PR DESCRIPTION
## Summary
- drop AWS CloudWatch logging dependency and configuration
- simplify CD workflow jar discovery to handle git-hash versions

## Testing
- `./backend/gradlew clean bootJar -x test` *(fails: Could not determine the dependencies of task ':bootJar' — Cannot find a Java installation ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa67bd6d2483209cfc2e6d26536aba