### PR TITLE
Add user repository support and user ID checks

### DIFF
--- a/backend/src/main/java/com/patentsight/patent/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/patentsight/patent/controller/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.patentsight.patent.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+}

--- a/backend/src/main/java/com/patentsight/patent/controller/PatentController.java
+++ b/backend/src/main/java/com/patentsight/patent/controller/PatentController.java
@@ -10,6 +10,8 @@ import com.patentsight.patent.dto.PatentResponse;
 import com.patentsight.patent.dto.SubmitPatentResponse;
 import com.patentsight.patent.service.PatentService;
 import com.patentsight.config.JwtTokenProvider;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,9 +34,12 @@ public class PatentController {
 
     // ------------------- CREATE -------------------
     @PostMapping
-    public ResponseEntity<PatentResponse> createPatent(@RequestBody PatentRequest request,
+    public ResponseEntity<PatentResponse> createPatent(@Valid @RequestBody PatentRequest request,
                                                        @RequestHeader("Authorization") String authorization) {
         Long userId = jwtTokenProvider.getUserIdFromHeader(authorization);
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         PatentResponse response = patentService.createPatent(request, userId);
         return ResponseEntity.ok(response);
     }
@@ -49,6 +54,9 @@ public class PatentController {
     @GetMapping("/my")
     public ResponseEntity<List<PatentResponse>> getMyPatents(@RequestHeader("Authorization") String authorization) {
         Long userId = jwtTokenProvider.getUserIdFromHeader(authorization);
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         List<PatentResponse> list = patentService.getMyPatents(userId);
         return ResponseEntity.ok(list);
     }
@@ -119,6 +127,9 @@ public class PatentController {
                                                                      @RequestBody DocumentVersionRequest request,
                                                                      @RequestHeader("Authorization") String authorization) {
         Long userId = jwtTokenProvider.getUserIdFromHeader(authorization);
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
         request.setApplicantId(userId);
         FileVersionResponse res = patentService.createDocumentVersion(id, request);
         return ResponseEntity.ok(res);

--- a/backend/src/main/java/com/patentsight/patent/dto/PatentRequest.java
+++ b/backend/src/main/java/com/patentsight/patent/dto/PatentRequest.java
@@ -1,19 +1,43 @@
 package com.patentsight.patent.dto;
 
 import com.patentsight.patent.domain.PatentType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public class PatentRequest {
+    @NotBlank
     private String title;
+
+    @NotNull
     private PatentType type;
+
+    @NotBlank
     private String cpc;
+
+    @NotBlank
     private String inventor;
+
+    @NotBlank
     private String technicalField;
+
+    @NotBlank
     private String backgroundTechnology;
+
+    @Valid
+    @NotNull
     private InventionDetails inventionDetails;
+
+    @NotBlank
     private String summary;
+
+    @NotBlank
     private String drawingDescription;
-    private List<String> claims;
+
+    @NotEmpty
+    private List<@NotBlank String> claims;
 
     public String getTitle() { return title; }
     public void setTitle(String title) { this.title = title; }
@@ -37,8 +61,13 @@ public class PatentRequest {
     public void setClaims(List<String> claims) { this.claims = claims; }
 
     public static class InventionDetails {
+        @NotBlank
         private String problemToSolve;
+
+        @NotBlank
         private String solution;
+
+        @NotBlank
         private String effect;
 
         public String getProblemToSolve() { return problemToSolve; }

--- a/backend/src/main/java/com/patentsight/patent/service/PatentService.java
+++ b/backend/src/main/java/com/patentsight/patent/service/PatentService.java
@@ -20,6 +20,8 @@ import com.patentsight.patent.dto.SubmitPatentResponse;
 import com.patentsight.ai.dto.PredictRequest;
 import com.patentsight.ai.dto.PredictResponse;
 import com.patentsight.patent.repository.PatentRepository;
+import com.patentsight.user.repository.UserRepository;
+import com.patentsight.user.domain.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -53,6 +55,7 @@ public class PatentService {
     private String fastApiIpcUrl;
 
     private final NotificationService notificationService;
+    private final UserRepository userRepository;
 
     public PatentService(PatentRepository patentRepository,
                          FileRepository fileRepository,
@@ -69,7 +72,7 @@ public class PatentService {
         this.restTemplate = restTemplate;
         this.notificationService = notificationService;
         this.reviewService = reviewService;
-        this.userRepository = userRepository;   // 👈 추가
+        this.userRepository = userRepository;
 
     }
 


### PR DESCRIPTION
## Summary
- add `UserRepository` and `User` imports to `PatentService`
- inject `UserRepository` into `PatentService` and use it to default inventor name
- handle missing user IDs in `PatentController` by returning 401 responses
- validate `PatentRequest` fields and surface errors through controller advice

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test` *(fails: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68aacca04b6c83208e4af537c2864a3b