### PR TITLE
Handle missing CPC when creating patents

### DIFF
--- a/backend/src/main/java/com/patentsight/patent/service/PatentService.java
+++ b/backend/src/main/java/com/patentsight/patent/service/PatentService.java
@@ -83,7 +83,9 @@ public class PatentService {
         patent.setType(request.getType());
         patent.setApplicantId(applicantId);
         patent.setStatus(PatentStatus.DRAFT);
-        patent.setCpc(request.getCpc());
+        // DB에서는 CPC 코드가 NOT NULL 제약을 가질 수 있으므로
+        // null이 전달되면 빈 문자열로 치환하여 저장한다.
+        patent.setCpc(request.getCpc() != null ? request.getCpc() : "");
         patent.setTechnicalField(request.getTechnicalField());
         patent.setBackgroundTechnology(request.getBackgroundTechnology());
 

--- a/frontend/applicant_fe/src/utils/documentState.js
+++ b/frontend/applicant_fe/src/utils/documentState.js
@@ -1,6 +1,11 @@
 // 문서 데이터의 초기 구조를 정의합니다.
 export const initialDocumentState = {
   title: '',
+  // 분류 코드(CPC)는 백엔드에서 NOT NULL 제약이 있으므로
+  // 초안 생성 시에도 빈 문자열로 전달한다.
+  cpc: '',
+  // 발명자명도 필수 컬럼이므로 기본값을 빈 문자열로 초기화한다.
+  inventor: '',
   technicalField: '',
   backgroundTechnology: '',
   inventionDetails: {


### PR DESCRIPTION
## Summary
- include `cpc` and `inventor` in initial document state sent by frontend
- default CPC to empty string on the backend when creating a patent

## Testing
- `./gradlew test` *(fails: NotificationServiceTest compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aad76d0e88832093a6947724532c5f