### PR TITLE
Increase patent claim text capacity

### DIFF
--- a/backend/src/main/java/com/patentsight/patent/domain/Patent.java
+++ b/backend/src/main/java/com/patentsight/patent/domain/Patent.java
@@ -54,7 +54,8 @@ public class Patent {
 
     @ElementCollection
     @CollectionTable(name = "patent_claims", joinColumns = @JoinColumn(name = "patent_id"))
-    @Column(name = "claim_text", columnDefinition = "TEXT")
+    @Lob
+    @Column(name = "claim_text", columnDefinition = "LONGTEXT")
     private List<String> claims;
 
     // getters and setters


### PR DESCRIPTION
## Summary
- allow longer claim text storage by using a `LONGTEXT` column and LOB mapping

## Testing
- `./gradlew test` *(fails: Could not resolve Java installation, toolchain auto-provisioning not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ab05d98d2c83208191f8b2aedeb5fc