### PR TITLE
Ensure inventor defaults to applicant on submission

### DIFF
--- a/backend/src/main/java/com/patentsight/patent/service/PatentService.java
+++ b/backend/src/main/java/com/patentsight/patent/service/PatentService.java
@@ -167,7 +167,15 @@ public class PatentService {
         if (latestRequest != null) {
             patent = updatePatentForSubmit(patentId, latestRequest);
         }
-    
+
+        // ✅ inventor 값이 비었으면 로그인한 사용자의 이름으로 세팅
+        if (patent.getInventor() == null || patent.getInventor().isBlank()) {
+            String userName = userRepository.findById(patent.getApplicantId())
+                    .map(User::getName)
+                    .orElse("미지정");
+            patent.setInventor(userName);
+        }
+
         // FastAPI 호출
         String firstClaim = patent.getClaims() != null && !patent.getClaims().isEmpty()
                 ? patent.getClaims().get(0) : "";


### PR DESCRIPTION
## Summary
- ensure inventor is populated with applicant's name during final submission

## Testing
- `cd backend && ./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1920be44832091edda5b7c5c19f9