### PR TITLE
Ensure inventor defaults to applicant on submission

### DIFF
--- a/backend/src/main/java/com/patentsight/patent/controller/PatentController.java
+++ b/backend/src/main/java/com/patentsight/patent/controller/PatentController.java
@@ -57,9 +57,11 @@ public class PatentController {
     // PatentController.java
     @PostMapping("/{id}/submit")
     public ResponseEntity<SubmitPatentResponse> submit(@PathVariable("id") Long id,
-                                                       @RequestBody(required = false) PatentRequest latestRequest) {
+                                                       @RequestBody(required = false) PatentRequest latestRequest,
+                                                       @RequestHeader("Authorization") String authorization) {
         // 프론트에서 보낸 JSON이 PatentRequest 구조와 동일해야 함 (title, technicalField 등 최상단에 위치)
-        SubmitPatentResponse res = patentService.submitPatent(id, latestRequest);
+        Long userId = jwtTokenProvider.getUserIdFromHeader(authorization);
+        SubmitPatentResponse res = patentService.submitPatent(id, latestRequest, userId);
         return ResponseEntity.ok(res);
     }
     

--- a/backend/src/test/java/com/patentsight/patent/service/PatentServiceTest.java
+++ b/backend/src/test/java/com/patentsight/patent/service/PatentServiceTest.java
@@ -11,8 +11,11 @@ import com.patentsight.patent.domain.PatentStatus;
 import com.patentsight.patent.domain.PatentType;
 import com.patentsight.patent.dto.PatentRequest;
 import com.patentsight.patent.dto.PatentResponse;
+import com.patentsight.patent.dto.SubmitPatentResponse;
 import com.patentsight.patent.repository.PatentRepository;
 import com.patentsight.review.service.ReviewService;
+import com.patentsight.user.domain.User;
+import com.patentsight.user.repository.UserRepository;
 import org.springframework.web.client.RestTemplate;
 import com.patentsight.ai.dto.PredictResponse;
 import org.junit.jupiter.api.Test;
@@ -52,6 +55,9 @@ class PatentServiceTest {
 
     @Mock
     private ReviewService reviewService;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private PatentService patentService;
@@ -176,8 +182,12 @@ class PatentServiceTest {
         when(patentRepository.save(any(Patent.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(restTemplate.postForObject(any(), any(), eq(PredictResponse.class))).thenReturn(null);
         doNothing().when(reviewService).autoAssignWithSpecialty(any(Patent.class));
+        User user100 = new User();
+        user100.setUserId(100L);
+        user100.setName("User100");
+        when(userRepository.findById(100L)).thenReturn(Optional.of(user100));
 
-        PatentResponse res = patentService.submitPatent(1L, null);
+        SubmitPatentResponse res = patentService.submitPatent(1L, null, 100L);
 
         assertNotNull(res);
         assertEquals(PatentStatus.SUBMITTED, res.getStatus());
@@ -198,8 +208,12 @@ class PatentServiceTest {
         when(patentRepository.save(any(Patent.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(restTemplate.postForObject(any(), any(), eq(PredictResponse.class))).thenReturn(null);
         doNothing().when(reviewService).autoAssignWithSpecialty(any(Patent.class));
+        User user200 = new User();
+        user200.setUserId(200L);
+        user200.setName("User200");
+        when(userRepository.findById(200L)).thenReturn(Optional.of(user200));
 
-        PatentResponse res = patentService.submitPatent(2L, null);
+        SubmitPatentResponse res = patentService.submitPatent(2L, null, 200L);
 
         assertNotNull(res);
         assertEquals(200L, res.getApplicantId());


### PR DESCRIPTION
## Summary
- pass Authorization header through submit endpoint to identify the current user
- default inventor field to logged-in user's name when missing during submission
- adjust service tests for new submit signature

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test` *(fails: NotificationServiceTest and outdated PatentServiceTest compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1920be44832091edda5b7c5c19f9