### PR TITLE
fix: sync review status naming with backend

### DIFF
--- a/backend/src/main/java/com/patentsight/review/service/OpinionNoticeService.java
+++ b/backend/src/main/java/com/patentsight/review/service/OpinionNoticeService.java
@@ -1,6 +1,7 @@
 package com.patentsight.review.service;
 
 import com.patentsight.patent.domain.PatentStatus;
+import com.patentsight.patent.repository.PatentRepository;
 import com.patentsight.review.domain.OpinionNotice;
 import com.patentsight.review.domain.OpinionType;
 import com.patentsight.review.domain.OpinionStatus;
@@ -11,6 +12,7 @@ import com.patentsight.review.repository.OpinionNoticeRepository;
 import com.patentsight.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,10 +20,12 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class OpinionNoticeService {
 
     private final OpinionNoticeRepository opinionNoticeRepository;
     private final ReviewRepository reviewRepository;
+    private final PatentRepository patentRepository;
 
     // 1️⃣ 의견서 생성
     public OpinionNoticeResponse createOpinionNotice(Long reviewId, OpinionNoticeRequest request) {
@@ -34,6 +38,8 @@ public class OpinionNoticeService {
             case REJECTION -> review.getPatent().setStatus(PatentStatus.REJECTED);
             case EXAMINER_OPINION -> review.getPatent().setStatus(PatentStatus.REVIEWING);
         }
+
+        patentRepository.saveAndFlush(review.getPatent());
 
         OpinionNotice notice = OpinionNotice.builder()
                 .review(review)

--- a/frontend/applicant_fe/src/components/PatentListModal.jsx
+++ b/frontend/applicant_fe/src/components/PatentListModal.jsx
@@ -7,7 +7,7 @@ import { DocumentTextIcon, ExclamationCircleIcon, CheckBadgeIcon, XMarkIcon } fr
 const statusMap = {
   DRAFT: '임시저장',
   SUBMITTED: '심사대기',
-  IN_REVIEW: '심사중',
+  REVIEWING: '심사중',
   APPROVED: '등록결정',
   REJECTED: '거절결정',
 };

--- a/frontend/applicant_fe/src/pages/MyPage.jsx
+++ b/frontend/applicant_fe/src/pages/MyPage.jsx
@@ -16,7 +16,7 @@ import PatentListModal from '../components/PatentListModal';
 const statusMap = {
   DRAFT: '임시저장',
   SUBMITTED: '심사대기',
-  IN_REVIEW: '심사중',
+  REVIEWING: '심사중',
   APPROVED: '등록결정',
   REJECTED: '거절결정',
 };
@@ -155,7 +155,7 @@ const MyPage = () => {
                             <strong>출원인:</strong> {patent.inventor || patent.applicantName || '미지정'} |
                             <span
                               className={`ml-2 px-2 py-1 rounded text-xs font-medium ${
-                                patent.status === 'IN_REVIEW'
+                                patent.status === 'REVIEWING'
                                   ? 'bg-yellow-100 text-yellow-800'
                                   : patent.status === 'SUBMITTED'
                                   ? 'bg-blue-100 text-blue-800'


### PR DESCRIPTION
## Summary
- align applicant-facing status names with backend (`REVIEWING`)
- ensure status badges display examiner decisions correctly
- persist patent status when an opinion notice finalizes a review

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68abc04550748320b36d80378a5f7491