### PR TITLE
Ensure patent status updates with review decisions

### DIFF
--- a/backend/src/main/java/com/patentsight/review/domain/Review.java
+++ b/backend/src/main/java/com/patentsight/review/domain/Review.java
@@ -2,6 +2,7 @@ package com.patentsight.review.domain;
 
 import com.patentsight.patent.domain.Patent;
 import com.patentsight.patent.domain.PatentType;
+import com.patentsight.patent.domain.PatentStatus;
 import com.patentsight.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -36,6 +37,18 @@ public class Review {
     private PatentType reviewType;
 
     private boolean autoAssigned; // 자동 배정 여부
+
+    public void setDecision(Decision decision) {
+        this.decision = decision;
+        if (this.patent != null) {
+            this.patent.setStatus(switch (decision) {
+                case SUBMITTED -> PatentStatus.SUBMITTED;
+                case REVIEWING -> PatentStatus.REVIEWING;
+                case APPROVE -> PatentStatus.APPROVED;
+                case REJECT -> PatentStatus.REJECTED;
+            });
+        }
+    }
     
     public enum Decision {
         SUBMITTED,  // 심사대기 (심사관 배정 직후)

--- a/backend/src/main/java/com/patentsight/review/service/OpinionNoticeService.java
+++ b/backend/src/main/java/com/patentsight/review/service/OpinionNoticeService.java
@@ -1,6 +1,5 @@
 package com.patentsight.review.service;
 
-import com.patentsight.patent.domain.PatentStatus;
 import com.patentsight.review.domain.OpinionNotice;
 import com.patentsight.review.domain.OpinionType;
 import com.patentsight.review.domain.OpinionStatus;
@@ -11,6 +10,7 @@ import com.patentsight.review.repository.OpinionNoticeRepository;
 import com.patentsight.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class OpinionNoticeService {
 
     private final OpinionNoticeRepository opinionNoticeRepository;
@@ -28,12 +29,15 @@ public class OpinionNoticeService {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new IllegalArgumentException("Review not found"));
 
-        // ✅ OpinionType에 따라 Patent 상태 변경
+        // ✅ OpinionType에 따라 Review/Patent 상태 동기화
         switch (request.getOpinionType()) {
-            case APPROVAL -> review.getPatent().setStatus(PatentStatus.APPROVED);
-            case REJECTION -> review.getPatent().setStatus(PatentStatus.REJECTED);
-            case EXAMINER_OPINION -> review.getPatent().setStatus(PatentStatus.REVIEWING);
+            case APPROVAL -> review.setDecision(Review.Decision.APPROVE);
+            case REJECTION -> review.setDecision(Review.Decision.REJECT);
+            case EXAMINER_OPINION -> review.setDecision(Review.Decision.REVIEWING);
         }
+
+        // Review 결정과 특허 상태를 함께 저장
+        reviewRepository.save(review);
 
         OpinionNotice notice = OpinionNotice.builder()
                 .review(review)

--- a/frontend/applicant_fe/src/components/PatentListModal.jsx
+++ b/frontend/applicant_fe/src/components/PatentListModal.jsx
@@ -7,7 +7,7 @@ import { DocumentTextIcon, ExclamationCircleIcon, CheckBadgeIcon, XMarkIcon } fr
 const statusMap = {
   DRAFT: '임시저장',
   SUBMITTED: '심사대기',
-  IN_REVIEW: '심사중',
+  REVIEWING: '심사중',
   APPROVED: '등록결정',
   REJECTED: '거절결정',
 };

--- a/frontend/applicant_fe/src/pages/MyPage.jsx
+++ b/frontend/applicant_fe/src/pages/MyPage.jsx
@@ -16,7 +16,7 @@ import PatentListModal from '../components/PatentListModal';
 const statusMap = {
   DRAFT: '임시저장',
   SUBMITTED: '심사대기',
-  IN_REVIEW: '심사중',
+  REVIEWING: '심사중',
   APPROVED: '등록결정',
   REJECTED: '거절결정',
 };
@@ -155,7 +155,7 @@ const MyPage = () => {
                             <strong>출원인:</strong> {patent.inventor || patent.applicantName || '미지정'} |
                             <span
                               className={`ml-2 px-2 py-1 rounded text-xs font-medium ${
-                                patent.status === 'IN_REVIEW'
+                                patent.status === 'REVIEWING'
                                   ? 'bg-yellow-100 text-yellow-800'
                                   : patent.status === 'SUBMITTED'
                                   ? 'bg-blue-100 text-blue-800'


### PR DESCRIPTION
## Summary
- Update Review entity to keep patent status in sync whenever a review decision changes
- Simplify opinion notice creation and review submission to rely on entity-level status updates

## Testing
- ❌ `./gradlew test` (missing Java 17 toolchain)
- ❌ `npm run lint` (frontend/examiner_fe: 15 lint errors)
- ✅ `npm run lint` (frontend/applicant_fe)


------
https://chatgpt.com/codex/tasks/task_e_68abc04550748320b36d80378a5f7491