### PR TITLE
feat: sync patent status with review decisions

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,6 +12,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
 
 management:
   endpoints:

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,32 @@
+-- Ensure patent.status reflects review.decision changes
+DROP TRIGGER IF EXISTS review_decision_update;
+CREATE TRIGGER review_decision_update
+AFTER UPDATE ON review
+FOR EACH ROW
+BEGIN
+    IF NEW.decision <> OLD.decision THEN
+        UPDATE patent
+        SET status = CASE NEW.decision
+            WHEN 'SUBMITTED' THEN 'SUBMITTED'
+            WHEN 'REVIEWING' THEN 'REVIEWING'
+            WHEN 'APPROVE' THEN 'APPROVED'
+            WHEN 'REJECT' THEN 'REJECTED'
+        END
+        WHERE patent_id = NEW.patent_id;
+    END IF;
+END;
+
+DROP TRIGGER IF EXISTS review_decision_insert;
+CREATE TRIGGER review_decision_insert
+AFTER INSERT ON review
+FOR EACH ROW
+BEGIN
+    UPDATE patent
+    SET status = CASE NEW.decision
+        WHEN 'SUBMITTED' THEN 'SUBMITTED'
+        WHEN 'REVIEWING' THEN 'REVIEWING'
+        WHEN 'APPROVE' THEN 'APPROVED'
+        WHEN 'REJECT' THEN 'REJECTED'
+    END
+    WHERE patent_id = NEW.patent_id;
+END;


### PR DESCRIPTION
## Summary
- ensure patent status updates whenever review.decision is inserted or changed via MySQL triggers
- enable SQL initialization at startup so triggers are created automatically

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68abe06856ac832093ebed0ffac1dbc5