### PR TITLE
feat: expose latest review retrieval

### DIFF
--- a/backend/src/main/java/com/patentsight/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/patentsight/review/controller/ReviewController.java
@@ -38,6 +38,12 @@ public class ReviewController {
         return reviewService.getReviewDetail(reviewId);
     }
 
+    // 4-1️⃣ 특정 특허의 최신 심사 결과 조회
+    @GetMapping("/patent/{patentId}")
+    public ReviewDetailResponse getLatestReviewByPatent(@PathVariable Long patentId) {
+        return reviewService.getLatestReviewByPatent(patentId);
+    }
+
     // 5️⃣ 심사 결과 제출
     @PostMapping("/submit")
     public Review submitReview(@RequestBody SubmitReviewRequest request) {

--- a/backend/src/main/java/com/patentsight/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/patentsight/review/repository/ReviewRepository.java
@@ -14,6 +14,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 🔹 특정 특허의 Review 조회
     List<Review> findByPatent_PatentId(Long patentId);
 
+    // 🔹 특정 특허의 가장 최근 Review 조회
+    Optional<Review> findTopByPatent_PatentIdOrderByReviewedAtDesc(Long patentId);
+
     // 🔹 상태별 Review 개수
     long countByDecision(Review.Decision decision);
 

--- a/backend/src/main/java/com/patentsight/review/service/ReviewService.java
+++ b/backend/src/main/java/com/patentsight/review/service/ReviewService.java
@@ -21,6 +21,9 @@ public interface ReviewService {
     // 4️⃣ 심사 상세 조회
     ReviewDetailResponse getReviewDetail(Long reviewId);
 
+    // 4-1️⃣ 특정 특허의 최신 심사 결과 조회
+    ReviewDetailResponse getLatestReviewByPatent(Long patentId);
+
     // 5️⃣ 심사 결과 제출
     Review submitReview(SubmitReviewRequest request);
 

--- a/backend/src/main/java/com/patentsight/review/service/ReviewServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/review/service/ReviewServiceImpl.java
@@ -215,11 +215,16 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = reviewRepository.findTopByPatent_PatentIdOrderByReviewedAtDesc(patentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."));
 
+        String comment = review.getComment();
+        if (review.getDecision() == Review.Decision.SUBMITTED) {
+            comment = "심사전입니다";
+        }
+
         return ReviewDetailResponse.builder()
                 .reviewId(review.getReviewId())
                 .patentId(review.getPatent().getPatentId())
                 .decision(review.getDecision())
-                .comment(review.getComment())
+                .comment(comment)
                 .reviewedAt(review.getReviewedAt())
                 .aiChecks(List.of())
                 .build();

--- a/backend/src/main/java/com/patentsight/review/service/ReviewServiceImpl.java
+++ b/backend/src/main/java/com/patentsight/review/service/ReviewServiceImpl.java
@@ -209,6 +209,22 @@ public class ReviewServiceImpl implements ReviewService {
                 .build();
     }
 
+    // 4-1️⃣ 특정 특허의 최신 심사 결과 조회
+    @Override
+    public ReviewDetailResponse getLatestReviewByPatent(Long patentId) {
+        Review review = reviewRepository.findTopByPatent_PatentIdOrderByReviewedAtDesc(patentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."));
+
+        return ReviewDetailResponse.builder()
+                .reviewId(review.getReviewId())
+                .patentId(review.getPatent().getPatentId())
+                .decision(review.getDecision())
+                .comment(review.getComment())
+                .reviewedAt(review.getReviewedAt())
+                .aiChecks(List.of())
+                .build();
+    }
+
     private String generateApplicationContent(Patent patent) {
         return "기술분야: " + patent.getTechnicalField() + "\n"
                 + "배경기술: " + patent.getBackgroundTechnology() + "\n"


### PR DESCRIPTION
## Summary
- allow fetching most recent review for a patent via repository and service
- expose `/api/reviews/patent/{patentId}` endpoint returning latest decision data

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68abea9ff8b88320b544aebb29a1c01a