### PR TITLE
feat(applicant): show patent review details

### DIFF
--- a/frontend/applicant_fe/src/api/reviews.js
+++ b/frontend/applicant_fe/src/api/reviews.js
@@ -1,0 +1,12 @@
+import axios from './axiosInstance';
+
+export const getReviewByPatentId = async (patentId) => {
+  try {
+    const res = await axios.get(`/api/reviews/patent/${patentId}`);
+    return res.data;
+  } catch (error) {
+    console.error('특허 리뷰 조회 실패:', error);
+    throw error;
+  }
+};
+

--- a/frontend/applicant_fe/src/pages/PatentDetail.jsx
+++ b/frontend/applicant_fe/src/pages/PatentDetail.jsx
@@ -6,6 +6,7 @@ import {
   updateFileContent,
   submitPatent
 } from '../api/patents';
+import { getReviewByPatentId } from '../api/reviews';
 import { useQueryClient } from '@tanstack/react-query';
 
 const PatentDetail = () => {
@@ -15,6 +16,7 @@ const PatentDetail = () => {
   const [patent, setPatent] = useState(null);
   const [fileContent, setFileContent] = useState('');
   const [fileId, setFileId] = useState(null);
+  const [review, setReview] = useState(null);
 
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState('');
@@ -64,6 +66,13 @@ const PatentDetail = () => {
         const file = await getLatestFile(id);
         setFileContent(file?.content || '');
         setFileId(file?.file_id || null);
+
+        try {
+          const reviewData = await getReviewByPatentId(id);
+          setReview(reviewData);
+        } catch (err) {
+          console.error('리뷰 조회 실패:', err);
+        }
       } catch (err) {
         console.error('데이터 로드 실패:', err);
       }
@@ -94,12 +103,19 @@ const PatentDetail = () => {
   if (!patent) return <div>로딩 중...</div>;
 
   const isSubmitted = patent.status === 'SUBMITTED';
+  const showReview = ['REVIEWING', 'APPROVED', 'REJECTED'].includes(patent.status);
 
   return (
     <div style={{ padding: '24px' }}>
       <h1>출원 상세: {patent.title}</h1>
       <p>유형: {patent.type}</p>
       <p>상태: {patent.status}</p>
+      {showReview && review && (
+        <div style={{ marginTop: '12px' }}>
+          <p>심사 결과: {review.decision}</p>
+          <p>심사 의견: {review.comment}</p>
+        </div>
+      )}
 
       <h2>📄 문서 본문</h2>
       <textarea


### PR DESCRIPTION
## Summary
- add API helper for fetching latest review by patent
- display review decision and comment on patent detail page when available

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68abed34332c8320988e02673f2d00a6