### PR TITLE
feat: improve patent detail page layout

### DIFF
--- a/frontend/applicant_fe/package-lock.json
+++ b/frontend/applicant_fe/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^9.30.1",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "globals": "^16.3.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "vite": "^7.0.4"
@@ -2736,6 +2737,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
+      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {

--- a/frontend/applicant_fe/package.json
+++ b/frontend/applicant_fe/package.json
@@ -33,6 +33,7 @@
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "vite": "^7.0.4"

--- a/frontend/applicant_fe/src/App.jsx
+++ b/frontend/applicant_fe/src/App.jsx
@@ -100,7 +100,8 @@ function App() {
               <Route path="/new-patent-choice" element={<NewPatentChoicePage />} />
               <Route path="/check/patents" element={<DraftsListPage />} />
               <Route path="/check/designs" element={<DesignCheckListPage />} />
-              <Route path="/patent/:id" element={<DocumentEditor />} />
+              <Route path="/patent/:id" element={<PatentDetail />} />
+              <Route path="/patent/:id/edit" element={<DocumentEditor />} />
               <Route path="/submit/:id" element={<FinalSubmitPage />} />
             </Routes>
           </MainContent>

--- a/frontend/applicant_fe/src/api/reviews.js
+++ b/frontend/applicant_fe/src/api/reviews.js
@@ -1,0 +1,12 @@
+import axios from './axiosInstance';
+
+export const getReviewByPatentId = async (patentId) => {
+  try {
+    const res = await axios.get(`/api/reviews/patent/${patentId}`);
+    return res.data;
+  } catch (error) {
+    console.error('특허 리뷰 조회 실패:', error);
+    throw error;
+  }
+};
+

--- a/frontend/applicant_fe/src/pages/DesignCheckListPage.jsx
+++ b/frontend/applicant_fe/src/pages/DesignCheckListPage.jsx
@@ -13,6 +13,7 @@ const DesignCheckListPage = () => {
   });
 
   const handleCardClick = (patentId) => {
+    // 상세보기 페이지로 이동
     navigate(`/patent/${patentId}`);
   };
 
@@ -20,7 +21,7 @@ const DesignCheckListPage = () => {
     <div className="min-h-screen bg-gray-100">
       <main className="p-8">
         <h1 className="text-3xl font-bold text-gray-800">디자인·상표 점검 (임시저장 목록)</h1>
-        <p className="mt-2 text-gray-600">임시저장된 디자인 및 상표 초안 목록입니다. 카드를 클릭하여 수정을 계속할 수 있습니다.</p>
+        <p className="mt-2 text-gray-600">임시저장된 디자인 및 상표 초안 목록입니다. 카드를 클릭하면 상세보기 페이지로 이동합니다.</p>
         <div className="mt-8 space-y-4">
           {isLoading && <p>목록을 불러오는 중입니다...</p>}
           {isError && <p>오류가 발생했습니다: {error.message}</p>}

--- a/frontend/applicant_fe/src/pages/DraftsListPage.jsx
+++ b/frontend/applicant_fe/src/pages/DraftsListPage.jsx
@@ -59,7 +59,7 @@ const DraftsListPage = () => {
   ) || [];
 
   const handleCardClick = (patentId) => {
-    // 임시저장된 문서는 편집기 페이지로 이동
+    // 문서를 클릭하면 상세보기 페이지로 이동
     navigate(`/patent/${patentId}`);
   };
 
@@ -67,7 +67,7 @@ const DraftsListPage = () => {
     <div className="max-w-screen-xl mx-auto px-4 py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-800">특허·실용신안 점검 (임시저장 목록)</h1>
-        <p className="mt-2 text-gray-600">임시저장된 특허 및 실용신안 초안 목록입니다. 카드를 클릭하여 수정을 계속할 수 있습니다.</p>
+        <p className="mt-2 text-gray-600">임시저장된 특허 및 실용신안 초안 목록입니다. 카드를 클릭하면 상세보기 페이지로 이동합니다.</p>
       </div>
 
       {isLoading && (

--- a/frontend/applicant_fe/src/pages/FinalSubmit.jsx
+++ b/frontend/applicant_fe/src/pages/FinalSubmit.jsx
@@ -73,7 +73,7 @@ const FinalSubmitPage = () => {
         </div>
 
         <div className="flex justify-end mt-6">
-          <button onClick={() => navigate(`/patent/${patentId}`)} className="px-6 py-2 mr-4 font-semibold text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
+          <button onClick={() => navigate(`/patent/${patentId}/edit`)} className="px-6 py-2 mr-4 font-semibold text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
             수정하러 가기
           </button>
           <button 

--- a/frontend/applicant_fe/src/pages/NewPatentChoice.jsx
+++ b/frontend/applicant_fe/src/pages/NewPatentChoice.jsx
@@ -16,7 +16,7 @@ const NewPatentChoicePage = () => {
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['myPatents'] });
       // [FIXED] 경로 맨 앞에 '/'를 추가하여 올바른 절대 경로로 수정합니다.
-      navigate(`/patent/${data.patentId}`);
+      navigate(`/patent/${data.patentId}/edit`);
     },
     onError: (err) => alert(`출원서 생성에 실패했습니다: ${err.message}`),
   });

--- a/frontend/applicant_fe/src/pages/PatentCheckListPage.jsx
+++ b/frontend/applicant_fe/src/pages/PatentCheckListPage.jsx
@@ -15,6 +15,7 @@ const PatentCheckListPage = () => {
   });
 
   const handleCardClick = (patentId) => {
+    // 상세보기 페이지로 이동
     navigate(`/patent/${patentId}`);
   };
 
@@ -22,7 +23,7 @@ const PatentCheckListPage = () => {
     <div className="min-h-screen bg-gray-100">
       <main className="p-8">
         <h1 className="text-3xl font-bold text-gray-800">특허·실용신안 점검 (임시저장 목록)</h1>
-        <p className="mt-2 text-gray-600">임시저장된 특허 및 실용신안 초안 목록입니다. 카드를 클릭하여 수정을 계속할 수 있습니다.</p>
+        <p className="mt-2 text-gray-600">임시저장된 특허 및 실용신안 초안 목록입니다. 카드를 클릭하면 상세보기 페이지로 이동합니다.</p>
         <div className="mt-8 space-y-4">
           {isLoading && <p>목록을 불러오는 중입니다...</p>}
           {isError && <p>오류가 발생했습니다: {error.message}</p>}

--- a/frontend/applicant_fe/src/pages/PatentDetail.jsx
+++ b/frontend/applicant_fe/src/pages/PatentDetail.jsx
@@ -1,69 +1,27 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom'; 
-import {
-  getPatentDetail,
-  getLatestFile,
-  updateFileContent,
-  submitPatent
-} from '../api/patents';
-import { useQueryClient } from '@tanstack/react-query';
+import { useParams, useNavigate } from 'react-router-dom';
+import { getPatentDetail } from '../api/patents';
+import { getReviewByPatentId } from '../api/reviews';
 
 const PatentDetail = () => {
   const { id } = useParams();
-  const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   const [patent, setPatent] = useState(null);
-  const [fileContent, setFileContent] = useState('');
-  const [fileId, setFileId] = useState(null);
+  const [review, setReview] = useState(null);
 
-  const [saving, setSaving] = useState(false);
-  const [saveStatus, setSaveStatus] = useState('');
-  const [submitStatus, setSubmitStatus] = useState('');
-
-  // ✅ 제출 요청
-  const handleSubmit = async () => {
-    setSubmitStatus('');
-    try {
-      const latestRequest = {
-        title: patent?.title || '',
-        type: patent?.type || 'PATENT', // 기본값 PATENT
-        cpc: patent?.cpc || '',
-        inventor: patent?.inventor ?? null,
-        technicalField: patent?.technicalField || '',
-        backgroundTechnology: patent?.backgroundTechnology || '',
-        inventionDetails: patent?.inventionDetails || {
-          problemToSolve: '',
-          solution: '',
-          effect: ''
-        },
-        summary: patent?.summary || '',
-        drawingDescription: patent?.drawingDescription || '',
-        claims: patent?.claims?.length ? patent.claims : ['']
-      };
-
-      const response = await submitPatent(id, latestRequest);
-
-      setPatent((prev) => ({ ...prev, status: response.status }));
-      queryClient.invalidateQueries(['myPatents']);
-      setSubmitStatus('✅ 제출 완료되었습니다.');
-    } catch (err) {
-      console.error('제출 실패:', err);
-      setSubmitStatus('❌ 제출에 실패했습니다.');
-    } finally {
-      setTimeout(() => setSubmitStatus(''), 3000);
-    }
-  };
-
-  // ✅ 최초 로딩
   useEffect(() => {
     async function fetchData() {
       try {
         const detail = await getPatentDetail(id);
         setPatent(detail);
 
-        const file = await getLatestFile(id);
-        setFileContent(file?.content || '');
-        setFileId(file?.file_id || null);
+        try {
+          const reviewData = await getReviewByPatentId(id);
+          setReview(reviewData);
+        } catch (err) {
+          console.error('리뷰 조회 실패:', err);
+        }
       } catch (err) {
         console.error('데이터 로드 실패:', err);
       }
@@ -72,70 +30,100 @@ const PatentDetail = () => {
     fetchData();
   }, [id]);
 
-  // ✅ 임시 저장
-  const handleSave = async () => {
-    if (!fileId) return;
-
-    setSaving(true);
-    setSaveStatus('');
-    try {
-      await updateFileContent(fileId, fileContent);
-      queryClient.invalidateQueries(['myPatents']);
-      setSaveStatus('✅ 임시 저장 완료');
-    } catch (err) {
-      console.error('임시 저장 실패:', err);
-      setSaveStatus('❌ 저장 실패');
-    } finally {
-      setSaving(false);
-      setTimeout(() => setSaveStatus(''), 2000);
-    }
-  };
-
   if (!patent) return <div>로딩 중...</div>;
 
-  const isSubmitted = patent.status === 'SUBMITTED';
+  const showReview = ['REVIEWING', 'APPROVED', 'REJECTED'].includes(patent.status);
+  const statusStyles = {
+    DRAFT: 'text-yellow-600 bg-yellow-100',
+    SUBMITTED: 'text-blue-600 bg-blue-100',
+    REVIEWING: 'text-purple-600 bg-purple-100',
+    APPROVED: 'text-green-600 bg-green-100',
+    REJECTED: 'text-red-600 bg-red-100',
+  };
 
   return (
-    <div style={{ padding: '24px' }}>
-      <h1>출원 상세: {patent.title}</h1>
-      <p>유형: {patent.type}</p>
-      <p>상태: {patent.status}</p>
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-screen-xl mx-auto px-4 py-8">
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-8">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-800">{patent.title || '제목 없음'}</h1>
+              <p className="text-gray-600 mt-1">출원 상세보기</p>
+            </div>
+            <div className="flex items-center gap-3">
+              <span
+                className={`px-3 py-1 rounded-full text-sm font-semibold ${statusStyles[patent.status] || 'text-gray-600 bg-gray-100'}`}
+              >
+                {patent.status}
+              </span>
+              <button
+                onClick={() => navigate(`/patent/${id}/edit`)}
+                className="px-4 py-2 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-all"
+              >
+                출원 편집
+              </button>
+            </div>
+          </div>
+          {showReview && review && (
+            <div className="mt-4 p-4 bg-gray-50 rounded-lg border border-gray-200">
+              <p className="font-semibold text-gray-700">심사 결과: <span className="font-normal">{review.decision}</span></p>
+              <p className="mt-2 text-gray-700">심사 의견: {review.comment}</p>
+            </div>
+          )}
+        </div>
 
-      <h2>📄 문서 본문</h2>
-      <textarea
-        value={fileContent}
-        onChange={(e) => setFileContent(e.target.value)}
-        rows={20}
-        disabled={isSubmitted}
-        style={{
-          width: '100%',
-          fontSize: '16px',
-          marginBottom: '12px',
-          backgroundColor: isSubmitted ? '#f2f2f2' : 'white',
-          color: isSubmitted ? '#999' : 'black'
-        }}
-      />
+        <div className="space-y-6">
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">기술분야</h2>
+            <p className="text-gray-700 whitespace-pre-wrap">{patent.technicalField || 'N/A'}</p>
+          </div>
 
-      <div>
-        <button
-          onClick={handleSave}
-          disabled={saving || isSubmitted}
-          style={{ padding: '8px 16px', marginRight: '12px' }}
-        >
-          {saving ? '저장 중...' : '임시 저장'}
-        </button>
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">배경기술</h2>
+            <p className="text-gray-700 whitespace-pre-wrap">{patent.backgroundTechnology || 'N/A'}</p>
+          </div>
 
-        <button
-          onClick={handleSubmit}
-          disabled={isSubmitted}
-          style={{ padding: '8px 16px' }}
-        >
-          제출
-        </button>
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-4">발명의 상세한 설명</h2>
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-md font-medium text-gray-700 mb-1">해결하려는 과제</h3>
+                <p className="text-gray-700 whitespace-pre-wrap">{patent.inventionDetails?.problemToSolve || 'N/A'}</p>
+              </div>
+              <div>
+                <h3 className="text-md font-medium text-gray-700 mb-1">과제의 해결 수단</h3>
+                <p className="text-gray-700 whitespace-pre-wrap">{patent.inventionDetails?.solution || 'N/A'}</p>
+              </div>
+              <div>
+                <h3 className="text-md font-medium text-gray-700 mb-1">발명의 효과</h3>
+                <p className="text-gray-700 whitespace-pre-wrap">{patent.inventionDetails?.effect || 'N/A'}</p>
+              </div>
+            </div>
+          </div>
 
-        <span style={{ marginLeft: '12px', color: '#444' }}>
-          {saveStatus || submitStatus}
-        </span>
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">요약</h2>
+            <p className="text-gray-700 whitespace-pre-wrap">{patent.summary || 'N/A'}</p>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-800 mb-2">도면의 간단한 설명</h2>
+            <p className="text-gray-700 whitespace-pre-wrap">{patent.drawingDescription || 'N/A'}</p>
+          </div>
+
+          {patent.claims && patent.claims.length > 0 && (
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-800 mb-2">청구범위</h2>
+              <div className="space-y-4">
+                {patent.claims.map((claim, index) => (
+                  <p key={index} className="text-gray-700 whitespace-pre-wrap">
+                    <span className="font-semibold">청구항 {index + 1}:</span> {claim}
+                  </p>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- style patent detail page similar to editor layout
- show full document sections and review info with status chip

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abed34332c8320988e02673f2d00a6