### PR TITLE
Include rejected reviews in completed dashboard count

### DIFF
--- a/frontend/examiner_fe/src/pages/DesignDashboard.jsx
+++ b/frontend/examiner_fe/src/pages/DesignDashboard.jsx
@@ -115,7 +115,7 @@ export default function DesignDashboard() {
           totalDesigns: listResponse.length,
           pending:   listResponse.filter(i => normalizeStatus(i.status) === 'SUBMITTED').length,
           inReview:  listResponse.filter(i => normalizeStatus(i.status) === 'REVIEWING').length,
-          completed: listResponse.filter(i => normalizeStatus(i.status) === 'APPROVED').length,
+          completed: listResponse.filter(i => ['APPROVED','REJECTED'].includes(normalizeStatus(i.status))).length,
           onhold:    listResponse.filter(i => normalizeStatus(i.status) === 'REJECTED').length,
         });
 

--- a/frontend/examiner_fe/src/pages/PatentDashboard.jsx
+++ b/frontend/examiner_fe/src/pages/PatentDashboard.jsx
@@ -144,7 +144,7 @@ export default function PatentDashboard() {
           totalPatents: source.length,
           pending:   source.filter(i => ['SUBMITTED'].includes(normalizeStatus(i.status))).length,
           inReview:  source.filter(i => ['REVIEWING','PENDING'].includes(normalizeStatus(i.status))).length,
-          completed: source.filter(i => ['APPROVED'].includes(normalizeStatus(i.status))).length,
+          completed: source.filter(i => ['APPROVED','REJECTED'].includes(normalizeStatus(i.status))).length,
           onhold:    source.filter(i => ['REJECTED'].includes(normalizeStatus(i.status))).length,
         });
 


### PR DESCRIPTION
## Summary
- Count both approved and rejected reviews as "completed" in patent examiner dashboard
- Do the same for design dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: no-empty, no-unused-vars, etc.)*
- `./gradlew test` *(fails: Could not resolve testRuntimeClasspath; missing JDK 17)*

------
https://chatgpt.com/codex/tasks/task_e_68abfed85be48320a59a1dfc41c9281a