### PR TITLE
Include rejected cases in dashboard completion stats

### DIFF
--- a/backend/src/main/java/com/patentsight/file/service/FileService.java
+++ b/backend/src/main/java/com/patentsight/file/service/FileService.java
@@ -93,7 +93,7 @@ public class FileService {
         res.setPatentId(attachment.getPatent() != null ? attachment.getPatent().getPatentId() : null);
         res.setUploaderId(attachment.getUploaderId());
         res.setFileName(attachment.getFileName());
-        res.setFileUrl(attachment.getFileUrl());
+        res.setFileUrl(FileUtil.getPublicUrl(attachment.getFileUrl()));
         res.setFileType(attachment.getFileType());
         res.setContent(attachment.getContent());
         res.setUpdatedAt(attachment.getUpdatedAt());

--- a/docs/patent-api.md
+++ b/docs/patent-api.md
@@ -143,8 +143,8 @@ curl -X POST "https://778efa9bea99.ngrok-free.app/generate" \
 
 | API 이름 | 설명 | Method | URL | 요청 데이터 | 응답 데이터 | 비고 |
 | --- | --- | --- | --- | --- | --- | --- |
-| UploadFile | 파일 업로드 | POST | /api/files | `file=@lock.png&patentId=1` | `{ "fileId":101,"patentId":1,"fileName":"lock.png","fileUrl":"/uploads/lock.png","uploaderId":1,"updatedAt":"2024-01-01T10:00:00" }` | Authorization 헤더 필요, multipart/form-data로 업로드 |
-| GetFileDetail | 파일 메타데이터 조회 | GET | /api/files/{fileId} | - | `{ "fileId":101,"patentId":1,"fileName":"lock.png","fileUrl":"/uploads/lock.png","uploaderId":1,"content":null,"updatedAt":"2024-01-01T10:00:00" }` | 실제 파일 다운로드는 fileUrl 사용 |
-| UpdateFile | 파일 교체 업로드 | PUT | /api/files/{fileId} | `file=@lock_v2.png` | `{ "fileId":101,"patentId":1,"fileName":"lock_v2.png","fileUrl":"/uploads/lock_v2.png","uploaderId":1,"updatedAt":"2024-01-02T09:00:00" }` | 기존 파일 삭제 후 새로 저장 |
+| UploadFile | 파일 업로드 | POST | /api/files | `file=@lock.png&patentId=1` | `{ "fileId":101,"patentId":1,"fileName":"lock.png","fileUrl":"https://bucket.s3.amazonaws.com/lock.png?X-Amz-Algorithm=...","uploaderId":1,"updatedAt":"2024-01-01T10:00:00" }` | Authorization 헤더 필요, multipart/form-data로 업로드 |
+| GetFileDetail | 파일 메타데이터 조회 | GET | /api/files/{fileId} | - | `{ "fileId":101,"patentId":1,"fileName":"lock.png","fileUrl":"https://bucket.s3.amazonaws.com/lock.png?X-Amz-Algorithm=...","uploaderId":1,"content":null,"updatedAt":"2024-01-01T10:00:00" }` | 실제 파일 다운로드는 fileUrl 사용 |
+| UpdateFile | 파일 교체 업로드 | PUT | /api/files/{fileId} | `file=@lock_v2.png` | `{ "fileId":101,"patentId":1,"fileName":"lock_v2.png","fileUrl":"https://bucket.s3.amazonaws.com/lock_v2.png?X-Amz-Algorithm=...","uploaderId":1,"updatedAt":"2024-01-02T09:00:00" }` | 기존 파일 삭제 후 새로 저장 |
 | DeleteFile | 파일 삭제 | DELETE | /api/files/{fileId} | - | `204 No Content` | 존재하지 않는 경우 404 반환 |
 

--- a/frontend/applicant_fe/src/api/files.js
+++ b/frontend/applicant_fe/src/api/files.js
@@ -1,7 +1,6 @@
 import axios from './axiosInstance';
 
 const API_ROOT = '/api/files';
-
 const isHttpUrl = (u) => /^https?:\/\//i.test(u);
 
 export function toAbsoluteFileUrl(u) {
@@ -9,12 +8,13 @@ export function toAbsoluteFileUrl(u) {
   if (isHttpUrl(u)) return u;
 
   const normalized = u.startsWith('/') ? u : `/${u.replace(/^\.?\//, '')}`;
+  const encPath = encodeURI(normalized);
   const base = axios.defaults.baseURL;
 
   if (base && isHttpUrl(base)) {
-    return base.replace(/\/+$/, '') + normalized;
+    return base.replace(/\/+$/, '') + encPath;
   }
-  return normalized;
+  return encPath;
 }
 
 export const parsePatentPdf = async (file) => {
@@ -33,7 +33,7 @@ export const parsePatentPdf = async (file) => {
 
 export const getFileDetail = async (fileId) => {
   const { data } = await axios.get(`${API_ROOT}/${fileId}`);
-  return data;
+  return { ...data, fileUrl: toAbsoluteFileUrl(data.fileUrl) };
 };
 
 const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp', 'svg']);
@@ -88,7 +88,8 @@ export const uploadFile = async ({ file, patentId }) => {
     const res = await axios.post(API_ROOT, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
-    return res.data;
+    const data = res.data;
+    return { ...data, fileUrl: toAbsoluteFileUrl(data.fileUrl) };
   } catch (error) {
     console.error('파일 업로드 실패:', error);
     throw error;

--- a/frontend/examiner_fe/src/pages/DesignDashboard.jsx
+++ b/frontend/examiner_fe/src/pages/DesignDashboard.jsx
@@ -115,7 +115,7 @@ export default function DesignDashboard() {
           totalDesigns: listResponse.length,
           pending:   listResponse.filter(i => normalizeStatus(i.status) === 'SUBMITTED').length,
           inReview:  listResponse.filter(i => normalizeStatus(i.status) === 'REVIEWING').length,
-          completed: listResponse.filter(i => normalizeStatus(i.status) === 'APPROVED').length,
+          completed: listResponse.filter(i => ['APPROVED','REJECTED'].includes(normalizeStatus(i.status))).length,
           onhold:    listResponse.filter(i => normalizeStatus(i.status) === 'REJECTED').length,
         });
 
@@ -316,7 +316,7 @@ export default function DesignDashboard() {
                   case 'reception':    return { completed: true, current: false };
                   case 'waiting':      return { completed: ['REVIEWING','APPROVED','REJECTED'].includes(item.status), current: item.status === 'SUBMITTED' };
                   case 'examination':  return { completed: ['APPROVED','REJECTED'].includes(item.status), current: item.status === 'REVIEWING' };
-                  case 'decision':     return { completed: ['APPROVED'].includes(item.status), current: ['APPROVED','REJECTED'].includes(item.status) };
+                  case 'decision':     return { completed: ['APPROVED','REJECTED'].includes(item.status), current: ['APPROVED','REJECTED'].includes(item.status) };
                   case 'registration': return { completed: ['APPROVED'].includes(item.status), current: ['APPROVED'].includes(item.status) };
                   default:             return { completed: false, current: false };
                 }

--- a/frontend/examiner_fe/src/pages/PatentDashboard.jsx
+++ b/frontend/examiner_fe/src/pages/PatentDashboard.jsx
@@ -144,7 +144,7 @@ export default function PatentDashboard() {
           totalPatents: source.length,
           pending:   source.filter(i => ['SUBMITTED'].includes(normalizeStatus(i.status))).length,
           inReview:  source.filter(i => ['REVIEWING','PENDING'].includes(normalizeStatus(i.status))).length,
-          completed: source.filter(i => ['APPROVED'].includes(normalizeStatus(i.status))).length,
+          completed: source.filter(i => ['APPROVED','REJECTED'].includes(normalizeStatus(i.status))).length,
           onhold:    source.filter(i => ['REJECTED'].includes(normalizeStatus(i.status))).length,
         });
 
@@ -356,7 +356,7 @@ export default function PatentDashboard() {
                   case 'reception':    return { completed: true, current: false };
                   case 'waiting':      return { completed: ['REVIEWING','PENDING','APPROVED','REJECTED'].includes(item.status), current: item.status === 'SUBMITTED' };
                   case 'examination':  return { completed: ['APPROVED','REJECTED'].includes(item.status), current: ['REVIEWING','PENDING'].includes(item.status) };
-                  case 'decision':     return { completed: ['APPROVED'].includes(item.status), current: ['APPROVED','REJECTED'].includes(item.status) };
+                  case 'decision':     return { completed: ['APPROVED','REJECTED'].includes(item.status), current: ['APPROVED','REJECTED'].includes(item.status) };
                   case 'registration': return { completed: ['APPROVED'].includes(item.status), current: ['APPROVED'].includes(item.status) };
                   default:             return { completed: false, current: false };
                 }


### PR DESCRIPTION
## Summary
- mark rejected reviews as completed in design and patent dashboards so completion count reflects all final decisions
- generate presigned S3 URLs and remove hardcoded bucket paths so attachments preview without AccessDenied errors

## Testing
- `npm test` (frontend/examiner_fe) *(fails: Missing script: "test")*
- `npm run lint` (frontend/examiner_fe) *(fails: no-unused-vars, no-empty, etc.)*
- `npm test` (frontend/applicant_fe) *(fails: Missing script: "test")*
- `npm run lint` (frontend/applicant_fe) *(fails: Cannot find package 'globals')*
- `./gradlew test` (backend) *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68abfed85be48320a59a1dfc41c9281a