### PR TITLE
Add FileUtil import to FileService

### DIFF
--- a/backend/src/main/java/com/patentsight/file/service/FileService.java
+++ b/backend/src/main/java/com/patentsight/file/service/FileService.java
@@ -7,6 +7,7 @@ import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.repository.FileRepository;
 import com.patentsight.patent.domain.Patent;
 import com.patentsight.patent.repository.PatentRepository;
+import com.patentsight.global.util.FileUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
## Summary
- add missing FileUtil import in FileService to enable usage of FileUtil#getPublicUrl

## Testing
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68ac24ca99b8832080e79f8832860186