### PR TITLE
fix: remove S3 ACL to avoid upload errors

### DIFF
--- a/backend/src/main/java/com/patentsight/global/util/FileUtil.java
+++ b/backend/src/main/java/com/patentsight/global/util/FileUtil.java
@@ -20,7 +20,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -89,7 +88,6 @@ public class FileUtil {
                     .bucket(BUCKET)
                     .key(name)
                     .contentType(file.getContentType())
-                    .acl(ObjectCannedACL.PUBLIC_READ)
                     .build();
             S3.putObject(req, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
             return name;


### PR DESCRIPTION
## Summary
- remove canned ACL from S3 put requests so uploads work even when bucket ownership enforces no ACLs

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68ac45cdbbb88320a3db9086c652a240