### PR TITLE
Validate S3 uploads and error on local paths

### DIFF
--- a/backend/src/main/java/com/patentsight/file/controller/FileController.java
+++ b/backend/src/main/java/com/patentsight/file/controller/FileController.java
@@ -4,6 +4,8 @@ import com.patentsight.config.JwtTokenProvider;
 import com.patentsight.file.dto.FileResponse;
 import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.service.FileService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +14,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/files")
 public class FileController {
+
+    private static final Logger log = LoggerFactory.getLogger(FileController.class);
 
     private final FileService fileService;
     private final JwtTokenProvider jwtTokenProvider;
@@ -60,6 +64,7 @@ public class FileController {
 
     @ExceptionHandler(S3UploadException.class)
     public ResponseEntity<String> handleS3UploadException(S3UploadException ex) {
+        log.error("S3 upload error: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ex.getMessage());
     }

--- a/backend/src/main/java/com/patentsight/file/service/FileService.java
+++ b/backend/src/main/java/com/patentsight/file/service/FileService.java
@@ -8,6 +8,8 @@ import com.patentsight.file.repository.FileRepository;
 import com.patentsight.global.util.FileUtil;
 import com.patentsight.patent.domain.Patent;
 import com.patentsight.patent.repository.PatentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,6 +20,8 @@ import java.time.LocalDateTime;
 @Service
 @Transactional
 public class FileService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileService.class);
 
     private final FileRepository fileRepository;
     private final PatentRepository patentRepository;
@@ -33,7 +37,7 @@ public class FileService {
      */
     public FileResponse create(MultipartFile file, Long uploaderId, Long patentId) {
         try {
-            String path = FileUtil.saveFile(file);
+            String path = ensureS3Key(FileUtil.saveFile(file));
             FileAttachment attachment = new FileAttachment();
             attachment.setUploaderId(uploaderId);
             attachment.setFileName(file.getOriginalFilename());
@@ -48,7 +52,8 @@ public class FileService {
             fileRepository.save(attachment);
             return toResponse(attachment);
         } catch (IOException e) {
-            throw new S3UploadException("Could not store file: " + e.getMessage(), e);
+            log.error("Could not store file on S3", e);
+            throw new S3UploadException("Could not store file on S3: " + e.getMessage(), e);
         }
     }
 
@@ -64,7 +69,7 @@ public class FileService {
         if (attachment == null) return null;
         try {
             FileUtil.deleteFile(attachment.getFileUrl());
-            String path = FileUtil.saveFile(file);
+            String path = ensureS3Key(FileUtil.saveFile(file));
             attachment.setFileName(file.getOriginalFilename());
             attachment.setFileUrl(path);
             attachment.setFileType(determineFileType(file.getOriginalFilename()));
@@ -72,7 +77,8 @@ public class FileService {
             fileRepository.save(attachment);
             return toResponse(attachment);
         } catch (IOException e) {
-            throw new S3UploadException("Could not update file: " + e.getMessage(), e);
+            log.error("Could not update file on S3", e);
+            throw new S3UploadException("Could not update file on S3: " + e.getMessage(), e);
         }
     }
 
@@ -85,6 +91,21 @@ public class FileService {
         }
         fileRepository.delete(attachment);
         return true;
+    }
+
+    /**
+     * Verifies that the provided storage path looks like an S3 object key. If the
+     * value resembles a local file-system path, an {@link S3UploadException} is
+     * thrown so callers can surface an error instead of continuing with an
+     * incorrect location.
+     */
+    private String ensureS3Key(String path) {
+        if (path == null || path.startsWith("/") || path.contains("uploads")) {
+            log.error("S3 upload failed; file stored locally at {}", path);
+            throw new S3UploadException(
+                    "S3 upload failed; file saved locally at '" + path + "'", null);
+        }
+        return path;
     }
 
     private FileResponse toResponse(FileAttachment attachment) {

--- a/backend/src/main/java/com/patentsight/global/util/FileUtil.java
+++ b/backend/src/main/java/com/patentsight/global/util/FileUtil.java
@@ -3,9 +3,6 @@ package com.patentsight.global.util;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -19,8 +16,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -29,10 +24,9 @@ import java.time.Duration;
 
 /**
  * Utility helpers for storing uploaded files. The primary storage target is
- * Amazon S3, but if AWS credentials are not configured or an upload/delete
- * operation fails, the file system under the {@code uploads} directory is used
- * as a graceful fallback so the application can continue to function in local
- * environments.
+ * Amazon S3. When S3 operations fail, an {@link IOException} is thrown so the
+ * caller can handle the error instead of silently falling back to the local
+ * file system.
  */
 public class FileUtil {
 
@@ -61,9 +55,6 @@ public class FileUtil {
     private static final S3Client S3 = S3Client.builder().region(REGION).build();
     private static final S3Presigner PRESIGNER = S3Presigner.builder().region(REGION).build();
 
-    // Local fallback directory for environments without S3 credentials
-    private static final Path BASE_DIR = Path.of("uploads");
-
     private static void ensureAwsCredentials(String action) throws IOException {
         try {
             DefaultCredentialsProvider.create().resolveCredentials();
@@ -74,9 +65,8 @@ public class FileUtil {
     }
 
     /**
-     * Saves the provided multipart file to S3. If credentials are missing or the
-     * upload fails, the file is stored on the local file system instead and the
-     * absolute path is returned.
+     * Saves the provided multipart file to S3 and returns the object key. If the
+     * upload fails for any reason, an {@link IOException} is thrown.
      */
     public static String saveFile(MultipartFile file) throws IOException {
         if (file == null || file.isEmpty()) {
@@ -89,23 +79,19 @@ public class FileUtil {
                     .bucket(BUCKET)
                     .key(name)
                     .contentType(file.getContentType())
-                    .acl(ObjectCannedACL.PUBLIC_READ)
                     .build();
             S3.putObject(req, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
             return name;
         } catch (Exception e) {
-            // Fall back to local file system
-            log.warn("S3 upload failed, storing file locally: {}", e.getMessage());
-            Files.createDirectories(BASE_DIR);
-            Path target = BASE_DIR.resolve(name).toAbsolutePath();
-            Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
-            return target.toString();
+            String message = "Failed to upload file to S3: " + e.getMessage();
+            log.error(message, e);
+            throw new IOException(message, e);
         }
     }
 
     /**
-     * Removes the stored file. Attempts S3 deletion first and falls back to
-     * deleting a local file if S3 interaction fails.
+     * Removes the stored file from S3. If deletion fails, an {@link IOException}
+     * is thrown so the caller can react accordingly.
      */
     public static void deleteFile(String key) throws IOException {
         if (key == null || key.isEmpty()) return;
@@ -117,12 +103,8 @@ public class FileUtil {
                     .build();
             S3.deleteObject(req);
         } catch (Exception e) {
-            log.warn("S3 delete failed, removing local file: {}", e.getMessage());
-            try {
-                Files.deleteIfExists(Path.of(key));
-            } catch (IOException ex) {
-                log.warn("Failed to delete local file '{}': {}", key, ex.getMessage());
-            }
+            log.error("S3 delete failed: {}", e.getMessage());
+            throw new IOException("Failed to delete file from S3", e);
         }
     }
 
@@ -133,7 +115,13 @@ public class FileUtil {
     public static String getPublicUrl(String key) {
         if (key == null || key.isEmpty()) return "";
         if (key.startsWith("http://") || key.startsWith("https://")) return key;
-        if (key.startsWith("/")) return key;
+        // If an absolute file-system path was persisted (e.g. "/home/ubuntu/uploads/…"),
+        // strip the leading directories so the remaining segment can be treated as an
+        // S3 object key. This prevents leaking local paths back to clients.
+        if (key.startsWith("/")) {
+            int idx = key.lastIndexOf('/') + 1;
+            key = key.substring(idx);
+        }
         try {
             ensureAwsCredentials("generate presigned URL for '" + key + "'");
             GetObjectRequest get = GetObjectRequest.builder()

--- a/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
+++ b/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
@@ -3,6 +3,7 @@ package com.patentsight.file.service;
 import com.patentsight.file.domain.FileAttachment;
 import com.patentsight.file.domain.FileType;
 import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.repository.FileRepository;
 import com.patentsight.global.util.FileUtil;
 import com.patentsight.patent.domain.Patent;
@@ -14,10 +15,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import org.mockito.MockedStatic;
+import java.io.IOException;
 
 @ExtendWith(MockitoExtension.class)
 class FileServiceTest {
@@ -51,19 +55,60 @@ class FileServiceTest {
         patent.setPatentId(10L);
         when(patentRepository.findById(10L)).thenReturn(java.util.Optional.of(patent));
 
-        FileResponse res = fileService.create(multipartFile, 99L, 10L);
+        try (MockedStatic<FileUtil> mocked = mockStatic(FileUtil.class)) {
+            mocked.when(() -> FileUtil.saveFile(any(MultipartFile.class))).thenReturn("stored/hello.pdf");
+            mocked.when(() -> FileUtil.getPublicUrl("stored/hello.pdf")).thenReturn("https://example.com/stored/hello.pdf");
+            mocked.when(() -> FileUtil.deleteFile(anyString())).thenAnswer(invocation -> null);
 
-        assertNotNull(res);
-        assertEquals(1L, res.getFileId());
-        assertEquals(99L, res.getUploaderId());
-        assertEquals(10L, res.getPatentId());
-        assertEquals("hello.pdf", res.getFileName());
-        assertEquals(FileType.PDF, res.getFileType());
-        assertNotNull(res.getFileUrl());
-        verify(fileRepository).save(any(FileAttachment.class));
+            FileResponse res = fileService.create(multipartFile, 99L, 10L);
 
-        // cleanup saved file
-        FileUtil.deleteFile(res.getFileUrl());
+            assertNotNull(res);
+            assertEquals(1L, res.getFileId());
+            assertEquals(99L, res.getUploaderId());
+            assertEquals(10L, res.getPatentId());
+            assertEquals("hello.pdf", res.getFileName());
+            assertEquals(FileType.PDF, res.getFileType());
+            assertEquals("https://example.com/stored/hello.pdf", res.getFileUrl());
+            verify(fileRepository).save(any(FileAttachment.class));
+
+            // cleanup saved file
+            FileUtil.deleteFile(res.getFileUrl());
+        }
+    }
+
+    @Test
+    void createThrowsWhenLocalPathReturned() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "img.png", "image/png", "data".getBytes());
+
+        Patent patent = new Patent();
+        patent.setPatentId(10L);
+        when(patentRepository.findById(10L)).thenReturn(java.util.Optional.of(patent));
+
+        try (MockedStatic<FileUtil> mocked = mockStatic(FileUtil.class)) {
+            mocked.when(() -> FileUtil.saveFile(any(MultipartFile.class))).thenReturn("/tmp/img.png");
+            S3UploadException ex = assertThrows(S3UploadException.class,
+                    () -> fileService.create(multipartFile, 1L, 10L));
+            assertTrue(ex.getMessage().contains("file saved locally"));
+        }
+    }
+
+    @Test
+    void createPropagatesS3FailureMessage() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "img.png", "image/png", "data".getBytes());
+
+        Patent patent = new Patent();
+        patent.setPatentId(10L);
+        when(patentRepository.findById(10L)).thenReturn(java.util.Optional.of(patent));
+
+        try (MockedStatic<FileUtil> mocked = mockStatic(FileUtil.class)) {
+            mocked.when(() -> FileUtil.saveFile(any(MultipartFile.class)))
+                    .thenThrow(new IOException("AccessDenied"));
+            S3UploadException ex = assertThrows(S3UploadException.class,
+                    () -> fileService.create(multipartFile, 1L, 10L));
+            assertTrue(ex.getMessage().contains("AccessDenied"));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- surface underlying S3 error messages when uploads fail
- reject local file paths with explicit message including the stored path
- cover S3 failure propagation in FileService tests
- log S3 upload failures in service and controller so the reason appears on the console

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies; SSLInitializationException due to missing trust store)*

------
https://chatgpt.com/codex/tasks/task_e_68ac45cdbbb88320a3db9086c652a240