### PR TITLE
Log S3 upload failures on client

### DIFF
--- a/backend/src/main/java/com/patentsight/file/controller/FileController.java
+++ b/backend/src/main/java/com/patentsight/file/controller/FileController.java
@@ -4,6 +4,8 @@ import com.patentsight.config.JwtTokenProvider;
 import com.patentsight.file.dto.FileResponse;
 import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.service.FileService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +14,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/files")
 public class FileController {
+
+    private static final Logger log = LoggerFactory.getLogger(FileController.class);
 
     private final FileService fileService;
     private final JwtTokenProvider jwtTokenProvider;
@@ -60,6 +64,7 @@ public class FileController {
 
     @ExceptionHandler(S3UploadException.class)
     public ResponseEntity<String> handleS3UploadException(S3UploadException ex) {
+        log.error("S3 upload error: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ex.getMessage());
     }

--- a/backend/src/main/java/com/patentsight/file/service/FileService.java
+++ b/backend/src/main/java/com/patentsight/file/service/FileService.java
@@ -8,6 +8,8 @@ import com.patentsight.file.repository.FileRepository;
 import com.patentsight.global.util.FileUtil;
 import com.patentsight.patent.domain.Patent;
 import com.patentsight.patent.repository.PatentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,6 +20,8 @@ import java.time.LocalDateTime;
 @Service
 @Transactional
 public class FileService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileService.class);
 
     private final FileRepository fileRepository;
     private final PatentRepository patentRepository;
@@ -33,7 +37,7 @@ public class FileService {
      */
     public FileResponse create(MultipartFile file, Long uploaderId, Long patentId) {
         try {
-            String path = FileUtil.saveFile(file);
+            String path = ensureS3Key(FileUtil.saveFile(file));
             FileAttachment attachment = new FileAttachment();
             attachment.setUploaderId(uploaderId);
             attachment.setFileName(file.getOriginalFilename());
@@ -48,7 +52,8 @@ public class FileService {
             fileRepository.save(attachment);
             return toResponse(attachment);
         } catch (IOException e) {
-            throw new S3UploadException("Could not store file: " + e.getMessage(), e);
+            log.error("Could not store file on S3", e);
+            throw new S3UploadException("Could not store file on S3: " + e.getMessage(), e);
         }
     }
 
@@ -64,7 +69,7 @@ public class FileService {
         if (attachment == null) return null;
         try {
             FileUtil.deleteFile(attachment.getFileUrl());
-            String path = FileUtil.saveFile(file);
+            String path = ensureS3Key(FileUtil.saveFile(file));
             attachment.setFileName(file.getOriginalFilename());
             attachment.setFileUrl(path);
             attachment.setFileType(determineFileType(file.getOriginalFilename()));
@@ -72,7 +77,8 @@ public class FileService {
             fileRepository.save(attachment);
             return toResponse(attachment);
         } catch (IOException e) {
-            throw new S3UploadException("Could not update file: " + e.getMessage(), e);
+            log.error("Could not update file on S3", e);
+            throw new S3UploadException("Could not update file on S3: " + e.getMessage(), e);
         }
     }
 
@@ -85,6 +91,21 @@ public class FileService {
         }
         fileRepository.delete(attachment);
         return true;
+    }
+
+    /**
+     * Verifies that the provided storage path looks like an S3 object key. If the
+     * value resembles a local file-system path, an {@link S3UploadException} is
+     * thrown so callers can surface an error instead of continuing with an
+     * incorrect location.
+     */
+    private String ensureS3Key(String path) {
+        if (path == null || path.startsWith("/") || path.contains("uploads")) {
+            log.error("S3 upload failed; file stored locally at {}", path);
+            throw new S3UploadException(
+                    "S3 upload failed; file saved locally at '" + path + "'", null);
+        }
+        return path;
     }
 
     private FileResponse toResponse(FileAttachment attachment) {

--- a/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
+++ b/backend/src/test/java/com/patentsight/file/service/FileServiceTest.java
@@ -3,6 +3,7 @@ package com.patentsight.file.service;
 import com.patentsight.file.domain.FileAttachment;
 import com.patentsight.file.domain.FileType;
 import com.patentsight.file.dto.FileResponse;
+import com.patentsight.file.exception.S3UploadException;
 import com.patentsight.file.repository.FileRepository;
 import com.patentsight.global.util.FileUtil;
 import com.patentsight.patent.domain.Patent;
@@ -14,10 +15,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import org.mockito.MockedStatic;
+import java.io.IOException;
 
 @ExtendWith(MockitoExtension.class)
 class FileServiceTest {
@@ -51,19 +55,60 @@ class FileServiceTest {
         patent.setPatentId(10L);
         when(patentRepository.findById(10L)).thenReturn(java.util.Optional.of(patent));
 
-        FileResponse res = fileService.create(multipartFile, 99L, 10L);
+        try (MockedStatic<FileUtil> mocked = mockStatic(FileUtil.class)) {
+            mocked.when(() -> FileUtil.saveFile(any(MultipartFile.class))).thenReturn("stored/hello.pdf");
+            mocked.when(() -> FileUtil.getPublicUrl("stored/hello.pdf")).thenReturn("https://example.com/stored/hello.pdf");
+            mocked.when(() -> FileUtil.deleteFile(anyString())).thenAnswer(invocation -> null);
 
-        assertNotNull(res);
-        assertEquals(1L, res.getFileId());
-        assertEquals(99L, res.getUploaderId());
-        assertEquals(10L, res.getPatentId());
-        assertEquals("hello.pdf", res.getFileName());
-        assertEquals(FileType.PDF, res.getFileType());
-        assertNotNull(res.getFileUrl());
-        verify(fileRepository).save(any(FileAttachment.class));
+            FileResponse res = fileService.create(multipartFile, 99L, 10L);
 
-        // cleanup saved file
-        FileUtil.deleteFile(res.getFileUrl());
+            assertNotNull(res);
+            assertEquals(1L, res.getFileId());
+            assertEquals(99L, res.getUploaderId());
+            assertEquals(10L, res.getPatentId());
+            assertEquals("hello.pdf", res.getFileName());
+            assertEquals(FileType.PDF, res.getFileType());
+            assertEquals("https://example.com/stored/hello.pdf", res.getFileUrl());
+            verify(fileRepository).save(any(FileAttachment.class));
+
+            // cleanup saved file
+            FileUtil.deleteFile(res.getFileUrl());
+        }
+    }
+
+    @Test
+    void createThrowsWhenLocalPathReturned() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "img.png", "image/png", "data".getBytes());
+
+        Patent patent = new Patent();
+        patent.setPatentId(10L);
+        when(patentRepository.findById(10L)).thenReturn(java.util.Optional.of(patent));
+
+        try (MockedStatic<FileUtil> mocked = mockStatic(FileUtil.class)) {
+            mocked.when(() -> FileUtil.saveFile(any(MultipartFile.class))).thenReturn("/tmp/img.png");
+            S3UploadException ex = assertThrows(S3UploadException.class,
+                    () -> fileService.create(multipartFile, 1L, 10L));
+            assertTrue(ex.getMessage().contains("file saved locally"));
+        }
+    }
+
+    @Test
+    void createPropagatesS3FailureMessage() throws Exception {
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "img.png", "image/png", "data".getBytes());
+
+        Patent patent = new Patent();
+        patent.setPatentId(10L);
+        when(patentRepository.findById(10L)).thenReturn(java.util.Optional.of(patent));
+
+        try (MockedStatic<FileUtil> mocked = mockStatic(FileUtil.class)) {
+            mocked.when(() -> FileUtil.saveFile(any(MultipartFile.class)))
+                    .thenThrow(new IOException("AccessDenied"));
+            S3UploadException ex = assertThrows(S3UploadException.class,
+                    () -> fileService.create(multipartFile, 1L, 10L));
+            assertTrue(ex.getMessage().contains("AccessDenied"));
+        }
     }
 }
 

--- a/backend/src/test/java/com/patentsight/global/util/FileUtilTest.java
+++ b/backend/src/test/java/com/patentsight/global/util/FileUtilTest.java
@@ -1,0 +1,20 @@
+package com.patentsight.global.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class FileUtilTest {
+    @Test
+    void convertsLocalHttpUrlToS3Path() {
+        String result = FileUtil.getPublicUrl("http://localhost/home/ubuntu/uploads/test.png");
+        assertTrue(result.endsWith("test.png"));
+        assertTrue(result.contains("patentsight-artifacts-usea1"));
+    }
+
+    @Test
+    void returnsS3UrlUnchanged() {
+        String s3 = "https://patentsight-artifacts-usea1.s3.us-east-1.amazonaws.com/test.png";
+        assertEquals(s3, FileUtil.getPublicUrl(s3));
+    }
+}

--- a/frontend/applicant_fe/src/api/files.js
+++ b/frontend/applicant_fe/src/api/files.js
@@ -98,7 +98,8 @@ export const uploadFile = async ({ file, patentId }) => {
     const data = res.data;
     return { ...data, fileUrl: toAbsoluteFileUrl(data.fileUrl) };
   } catch (error) {
-    console.error('파일 업로드 실패:', error);
-    throw error;
+    const msg = error.response?.data || error.message;
+    console.error('S3 업로드 실패:', msg);
+    throw new Error(msg);
   }
 };

--- a/frontend/examiner_fe/src/api/files.js
+++ b/frontend/examiner_fe/src/api/files.js
@@ -87,19 +87,31 @@ export async function uploadFile({ file, patentId }) {
   const form = new FormData();
   form.append('file', file);
   if (patentId != null) form.append('patentId', patentId);
-  const { data } = await axiosInstance.post(API_ROOT, form, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
-  return { ...data, fileUrl: toAbsoluteFileUrl(data.fileUrl) }; // { fileId, patentId, fileName, fileUrl, ... }
+  try {
+    const { data } = await axiosInstance.post(API_ROOT, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    return { ...data, fileUrl: toAbsoluteFileUrl(data.fileUrl) }; // { fileId, patentId, fileName, fileUrl, ... }
+  } catch (error) {
+    const msg = error.response?.data || error.message;
+    console.error('S3 업로드 실패:', msg);
+    throw new Error(msg);
+  }
 }
 
 export async function updateFile(fileId, file) {
   const form = new FormData();
   form.append('file', file);
-  const { data } = await axiosInstance.put(`${API_ROOT}/${fileId}`, form, {
-    headers: { 'Content-Type': 'multipart/form-data' },
-  });
-  return { ...data, fileUrl: toAbsoluteFileUrl(data.fileUrl) };
+  try {
+    const { data } = await axiosInstance.put(`${API_ROOT}/${fileId}`, form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    return { ...data, fileUrl: toAbsoluteFileUrl(data.fileUrl) };
+  } catch (error) {
+    const msg = error.response?.data || error.message;
+    console.error('S3 업로드 실패:', msg);
+    throw new Error(msg);
+  }
 }
 
 export async function deleteFile(fileId) {


### PR DESCRIPTION
## Summary
- surface S3 upload failures in applicant file uploads by logging server error messages in the browser console
- add similar error handling for examiner file uploads and updates
- default backend S3 bucket to `patentsight-artifacts-usea1` so uploads hit the correct bucket
- normalize stored file paths so any local URLs are converted to public S3 links

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test` *(failed: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68ac45cdbbb88320a3db9086c652a240