### PR TITLE
Fix DocumentEditor drawing image URLs

### DIFF
--- a/frontend/applicant_fe/src/pages/DocumentEditor.jsx
+++ b/frontend/applicant_fe/src/pages/DocumentEditor.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { submitPatent, getPatentDetail, updateDocument, validatePatentDocument, generateFullDraft } from '../api/patents';
-import { uploadFile } from '../api/files';
+import { uploadFile, toAbsoluteFileUrl } from '../api/files';
 import { 
   FileText, Save, Download, Send, Bot, Box, CheckCircle, AlertCircle, X,
   Plus, Trash2, Eye, Edit3, AlertTriangle
@@ -300,7 +300,7 @@ const DocumentEditor = () => {
                   <input type="file" multiple accept="image/png, image/jpeg" onChange={handleDrawingUpload} className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"/>
                   {isUploading && <p className="text-sm text-gray-500 mt-2">업로드 중...</p>}
                   {uploadError && <p className="text-sm text-red-500 mt-2">{uploadError}</p>}
-                  <div className="grid grid-cols-3 gap-4 mt-4">{drawingFiles.map((f, index) => (<div key={f.fileId || index} className="border rounded-lg overflow-hidden"><img src={f.fileUrl} alt={`도면 미리보기 ${index + 1}`} className="w-full h-auto object-cover" /></div>))}</div>
+                  <div className="grid grid-cols-3 gap-4 mt-4">{drawingFiles.map((f, index) => (<div key={f.fileId || index} className="border rounded-lg overflow-hidden"><img src={toAbsoluteFileUrl(f.fileUrl)} alt={`도면 미리보기 ${index + 1}`} className="w-full h-auto object-cover" /></div>))}</div>
                 </div>
               )}
             </div>

--- a/frontend/examiner_fe/src/api/files.js
+++ b/frontend/examiner_fe/src/api/files.js
@@ -4,16 +4,34 @@ import axiosInstance from './axiosInstance';
 const API_ROOT = '/api/files';
 const isHttpUrl = (u) => /^https?:\/\//i.test(u);
 
+// 전역에서 주입되지 않으면 기본 퍼블릭 버킷 URL을 사용
+const S3_PUBLIC_BASE =
+  (typeof globalThis !== 'undefined' && globalThis.S3_PUBLIC_BASE) ||
+  'https://patentsight-artifacts-usea1.s3.us-east-1.amazonaws.com';
+
 // 백엔드가 '/uploads/...' 같은 경로 또는 S3 키를 줄 때 절대 URL로 보정
 export function toAbsoluteFileUrl(u) {
   if (!u) return '';
-  if (isHttpUrl(u)) return u;
+
+  // 백엔드가 로컬 절대/상대 경로 혹은 http://.../uploads/... 형태를 줄 수 있다.
+  // 이런 경우 마지막 파일명만 추출해 S3 퍼블릭 URL로 변환
+  const toS3 = (p) => {
+    const [key, query] = p.split('?');
+    const name = key.substring(key.lastIndexOf('/') + 1);
+    const encoded = encodeURIComponent(name);
+    return `${S3_PUBLIC_BASE}/${encoded}${query ? `?${query}` : ''}`;
+  };
+
+  if (isHttpUrl(u)) {
+    if (u.includes('/uploads/')) return toS3(u);
+    return u;
+  }
+
+  if (u.includes('/uploads/')) return toS3(u);
 
   // S3 키(슬래시 없음)라면 퍼블릭 URL로 변환 + 인코딩
   if (!u.startsWith('/')) {
-    const [key, query] = u.split('?');
-    const encodedKey = encodeURIComponent(key);
-    return `${S3_PUBLIC_BASE}/${encodedKey}${query ? `?${query}` : ''}`;
+    return toS3(u);
   }
 
   const normalized = u.startsWith('/') ? u : `/${u.replace(/^\.?\//, '')}`;


### PR DESCRIPTION
## Summary
- ensure applicant DocumentEditor renders drawing images with S3 URLs

## Testing
- `npx eslint src/pages/DocumentEditor.jsx`
- `./backend/gradlew -p backend test`

------
https://chatgpt.com/codex/tasks/task_e_68ac6bd6b15c8320abe0a28445034d4a