### PR TITLE
fix: handle multiple PIDs in EC2 deploy

### DIFF
--- a/.github/workflows/cd-backend-ec2.yml
+++ b/.github/workflows/cd-backend-ec2.yml
@@ -88,8 +88,26 @@ jobs:
             echo "Deploying: $TARGET_JAR"
 
             if [ ! -f "$TARGET_JAR" ]; then
-              echo "ERROR: $TARGET_JAR not found"; exit 1
+              echo "ERROR: $TARGET_JAR not found" >&2
+              exit 1
             fi
 
-            "$APP_DIR/deploy.sh" "$TARGET_JAR"
+            cd "$APP_DIR"
+
+            PID=$(pgrep -f "current.jar" || true)
+            if [ -n "$PID" ]; then
+              echo "> 실행 중인 애플리케이션(PID: $PID)을 종료합니다."
+              echo "$PID" | xargs -r kill || true
+              sleep 5
+              PID=$(pgrep -f "current.jar" || true)
+              if [ -n "$PID" ]; then
+                echo "> 프로세스가 아직 살아있습니다. 강제 종료합니다."
+                echo "$PID" | xargs -r kill -9 || true
+              fi
+            fi
+
+            ln -sfn "$TARGET_JAR" "$APP_DIR/current.jar"
+            nohup java -jar "$APP_DIR/current.jar" > "$APP_DIR/app.log" 2>&1 &
+            echo "> 새 애플리케이션 실행"
+            echo "✅ 배포 완료"
 


### PR DESCRIPTION
## Summary
- inline EC2 deployment logic in workflow to avoid `kill` errors
- stop existing app using `pgrep` and `xargs kill` to handle multiple PIDs

## Testing
- `actionlint .github/workflows/cd-backend-ec2.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ac8556c09083209cb5ed4684f52663