### PR TITLE
Add file download endpoint with streaming and 3D model viewer

### DIFF
--- a/backend/src/main/java/com/patentsight/file/repository/FileRepository.java
+++ b/backend/src/main/java/com/patentsight/file/repository/FileRepository.java
@@ -1,12 +1,16 @@
 package com.patentsight.file.repository;
 
 import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.domain.FileType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FileRepository extends JpaRepository<FileAttachment, Long> {
 
     // ★ 추가된 부분: 특정 특허에 속한 파일만 조회
     List<FileAttachment> findByPatent_PatentId(Long patentId);
+
+    Optional<FileAttachment> findTopByPatent_PatentIdAndFileType(Long patentId, FileType fileType);
 }

--- a/backend/src/main/java/com/patentsight/global/util/FileUtil.java
+++ b/backend/src/main/java/com/patentsight/global/util/FileUtil.java
@@ -129,12 +129,12 @@ public class FileUtil {
             return Files.readAllBytes(path);
         }
         ensureAwsCredentials("download object '" + key + "'");
-        try {
-            GetObjectRequest req = GetObjectRequest.builder()
-                    .bucket(BUCKET)
-                    .key(key)
-                    .build();
-            return S3.getObjectAsBytes(req).asByteArray();
+        GetObjectRequest req = GetObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(key)
+                .build();
+        try (InputStream in = S3.getObject(req)) {
+            return in.readAllBytes();
         } catch (S3Exception | SdkClientException e) {
             throw new IOException("S3 download failed: " + e.getMessage(), e);
         }

--- a/frontend/applicant_fe/src/components/PatentDetailModal.jsx
+++ b/frontend/applicant_fe/src/components/PatentDetailModal.jsx
@@ -2,31 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { getImageUrlsByIds, getNonImageFilesByIds } from '../api/files';
-
-function ModelViewer3D({ src }) {
-  useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div style={{ width: '100%', height: '200px', backgroundColor: '#f3f4f6', borderRadius: '8px', overflow: 'hidden' }}>
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
+import ThreeDModelViewer from './ThreeDModelViewer';
 
 const PatentDetailModal = ({ patent, onClose }) => {
   const [images, setImages] = useState([]);
@@ -98,31 +74,27 @@ const PatentDetailModal = ({ patent, onClose }) => {
           <strong>요약:</strong> {patent.summary}
         </p>
         <h3 style={{ marginTop: '16px' }}>도면에 대한 설명</h3>
-        {(images.length > 0 || glbUrl) && (
+        {images.length > 0 && (
+          <div style={{ marginBottom: '16px', marginTop: '8px', display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+            {images.map((src, idx) => (
+              <img
+                key={idx}
+                src={src}
+                alt={`도면 ${idx + 1}`}
+                style={{
+                  width: '100px',
+                  height: '100px',
+                  objectFit: 'contain',
+                  border: '1px solid #e5e7eb',
+                  borderRadius: '4px',
+                }}
+              />
+            ))}
+          </div>
+        )}
+        {glbUrl && (
           <div style={{ marginBottom: '16px' }}>
-            {images.length > 0 && (
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginTop: '8px' }}>
-                {images.map((src, idx) => (
-                  <img
-                    key={idx}
-                    src={src}
-                    alt={`도면 ${idx + 1}`}
-                    style={{
-                      width: '100px',
-                      height: '100px',
-                      objectFit: 'contain',
-                      border: '1px solid #e5e7eb',
-                      borderRadius: '4px',
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-            {glbUrl && (
-              <div style={{ marginTop: '16px' }}>
-                <ModelViewer3D src={glbUrl} />
-              </div>
-            )}
+            <ThreeDModelViewer src={glbUrl} />
           </div>
         )}
         <p>{patent.drawingDescription || 'N/A'}</p>

--- a/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
+++ b/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+
+const ThreeDModelViewer = ({ src }) => {
+  useEffect(() => {
+    if (!window.customElements || !window.customElements.get('model-viewer')) {
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
+      document.head.appendChild(script);
+    }
+  }, []);
+
+  return (
+    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
+      {/* @ts-ignore */}
+      <model-viewer
+        style={{ width: '100%', height: '100%' }}
+        src={src}
+        camera-controls
+        auto-rotate
+        exposure="1.0"
+        shadow-intensity="1"
+        ar
+      />
+    </div>
+  );
+};
+
+export default ThreeDModelViewer;

--- a/frontend/applicant_fe/src/pages/PatentDetail.jsx
+++ b/frontend/applicant_fe/src/pages/PatentDetail.jsx
@@ -3,31 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { getPatentDetail } from '../api/patents';
 import { getReviewByPatentId } from '../api/reviews';
 import { getImageUrlsByIds, getNonImageFilesByIds } from '../api/files';
-
-function ModelViewer3D({ src }) {
-  useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
+import ThreeDModelViewer from '../components/ThreeDModelViewer';
 
 const PatentDetail = () => {
   const { id } = useParams();
@@ -166,24 +142,25 @@ const PatentDetail = () => {
             <p className="text-gray-700 whitespace-pre-wrap">{patent.summary || 'N/A'}</p>
           </div>
 
-          {(images.length > 0 || glbUrl) && (
+          {images.length > 0 && (
             <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
               <h2 className="text-lg font-semibold text-gray-800 mb-2">도면</h2>
-              <div className="space-y-4">
-                {images.length > 0 && (
-                  <div className="flex flex-wrap gap-4">
-                    {images.map((src, idx) => (
-                      <img
-                        key={idx}
-                        src={src}
-                        alt={`drawing-${idx}`}
-                        className="max-w-full h-48 object-contain rounded border border-gray-200"
-                      />
-                    ))}
-                  </div>
-                )}
-                {glbUrl && <ModelViewer3D src={glbUrl} />}
+              <div className="flex flex-wrap gap-4">
+                {images.map((src, idx) => (
+                  <img
+                    key={idx}
+                    src={src}
+                    alt={`drawing-${idx}`}
+                    className="max-w-full h-48 object-contain rounded border border-gray-200"
+                  />
+                ))}
               </div>
+            </div>
+          )}
+          {glbUrl && (
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-800 mb-2">3D 모델</h2>
+              <ThreeDModelViewer src={glbUrl} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- add `/api/files/{id}/content` endpoint returning file bytes with content type
- support loading attachment content via `FileService.loadContent`
- stream object bytes from S3 in `FileUtil.downloadFile`
- show GLB files in dedicated 3D model sections for editor and detail views
- ensure each patent stores at most one GLB file

## Testing
- `./gradlew test` *(failed: SSL initialization while resolving dependencies)*
- `npm test --prefix frontend/applicant_fe` *(failed: missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad114c53f08320aa2e059cbb1d7828