### PR TITLE
Serve GLB models through backend endpoint

### DIFF
--- a/backend/src/main/java/com/patentsight/file/repository/FileRepository.java
+++ b/backend/src/main/java/com/patentsight/file/repository/FileRepository.java
@@ -1,12 +1,16 @@
 package com.patentsight.file.repository;
 
 import com.patentsight.file.domain.FileAttachment;
+import com.patentsight.file.domain.FileType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FileRepository extends JpaRepository<FileAttachment, Long> {
 
     // ★ 추가된 부분: 특정 특허에 속한 파일만 조회
     List<FileAttachment> findByPatent_PatentId(Long patentId);
+
+    Optional<FileAttachment> findTopByPatent_PatentIdAndFileType(Long patentId, FileType fileType);
 }

--- a/backend/src/main/java/com/patentsight/global/util/FileUtil.java
+++ b/backend/src/main/java/com/patentsight/global/util/FileUtil.java
@@ -129,12 +129,12 @@ public class FileUtil {
             return Files.readAllBytes(path);
         }
         ensureAwsCredentials("download object '" + key + "'");
-        try {
-            GetObjectRequest req = GetObjectRequest.builder()
-                    .bucket(BUCKET)
-                    .key(key)
-                    .build();
-            return S3.getObjectAsBytes(req).asByteArray();
+        GetObjectRequest req = GetObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(key)
+                .build();
+        try (InputStream in = S3.getObject(req)) {
+            return in.readAllBytes();
         } catch (S3Exception | SdkClientException e) {
             throw new IOException("S3 download failed: " + e.getMessage(), e);
         }

--- a/frontend/applicant_fe/src/components/PatentDetailModal.jsx
+++ b/frontend/applicant_fe/src/components/PatentDetailModal.jsx
@@ -2,31 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { getImageUrlsByIds, getNonImageFilesByIds } from '../api/files';
-
-function ModelViewer3D({ src }) {
-  useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div style={{ width: '100%', height: '200px', backgroundColor: '#f3f4f6', borderRadius: '8px', overflow: 'hidden' }}>
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
+import ThreeDModelViewer from './ThreeDModelViewer';
 
 const PatentDetailModal = ({ patent, onClose }) => {
   const [images, setImages] = useState([]);
@@ -47,7 +23,7 @@ const PatentDetailModal = ({ patent, onClose }) => {
               /\.glb($|\?|#)/i.test(f.name || '') ||
               /\.glb($|\?|#)/i.test(f.url || '')
           );
-          setGlbUrl(glb ? glb.url : '');
+          setGlbUrl(glb ? `/api/files/${glb.id}/content` : '');
         } catch (err) {
           console.error('첨부 파일 로드 실패:', err);
         }
@@ -98,31 +74,27 @@ const PatentDetailModal = ({ patent, onClose }) => {
           <strong>요약:</strong> {patent.summary}
         </p>
         <h3 style={{ marginTop: '16px' }}>도면에 대한 설명</h3>
-        {(images.length > 0 || glbUrl) && (
+        {images.length > 0 && (
+          <div style={{ marginBottom: '16px', marginTop: '8px', display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+            {images.map((src, idx) => (
+              <img
+                key={idx}
+                src={src}
+                alt={`도면 ${idx + 1}`}
+                style={{
+                  width: '100px',
+                  height: '100px',
+                  objectFit: 'contain',
+                  border: '1px solid #e5e7eb',
+                  borderRadius: '4px',
+                }}
+              />
+            ))}
+          </div>
+        )}
+        {glbUrl && (
           <div style={{ marginBottom: '16px' }}>
-            {images.length > 0 && (
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginTop: '8px' }}>
-                {images.map((src, idx) => (
-                  <img
-                    key={idx}
-                    src={src}
-                    alt={`도면 ${idx + 1}`}
-                    style={{
-                      width: '100px',
-                      height: '100px',
-                      objectFit: 'contain',
-                      border: '1px solid #e5e7eb',
-                      borderRadius: '4px',
-                    }}
-                  />
-                ))}
-              </div>
-            )}
-            {glbUrl && (
-              <div style={{ marginTop: '16px' }}>
-                <ModelViewer3D src={glbUrl} />
-              </div>
-            )}
+            <ThreeDModelViewer src={glbUrl} />
           </div>
         )}
         <p>{patent.drawingDescription || 'N/A'}</p>

--- a/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
+++ b/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+
+const ThreeDModelViewer = ({ src }) => {
+  useEffect(() => {
+    if (!window.customElements || !window.customElements.get('model-viewer')) {
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
+      document.head.appendChild(script);
+    }
+  }, []);
+
+  return (
+    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
+      {/* @ts-ignore */}
+      <model-viewer
+        style={{ width: '100%', height: '100%' }}
+        src={src}
+        camera-controls
+        auto-rotate
+        exposure="1.0"
+        shadow-intensity="1"
+        ar
+      />
+    </div>
+  );
+};
+
+export default ThreeDModelViewer;

--- a/frontend/applicant_fe/src/pages/DocumentEditor.jsx
+++ b/frontend/applicant_fe/src/pages/DocumentEditor.jsx
@@ -1,14 +1,34 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { submitPatent, getPatentDetail, updateDocument, validatePatentDocument, generateFullDraft, generate3DModel } from '../api/patents';
+import {
+  submitPatent,
+  getPatentDetail,
+  updateDocument,
+  validatePatentDocument,
+  generateFullDraft,
+  generate3DModel,
+} from '../api/patents';
 import { uploadFile } from '../api/files';
-import { 
-  FileText, Save, Download, Send, Bot, Box, CheckCircle, AlertCircle, X,
-  Plus, Trash2, Eye, Edit3, AlertTriangle
+import {
+  FileText,
+  Save,
+  Download,
+  Send,
+  Bot,
+  Box,
+  CheckCircle,
+  AlertCircle,
+  X,
+  Plus,
+  Trash2,
+  Eye,
+  Edit3,
+  AlertTriangle,
 } from 'lucide-react';
 import GenerateDraftModal from '../pages/GenerateDraftModal';
 import Button from '../components/Button';
+import ThreeDModelViewer from '../components/ThreeDModelViewer';
 import { initialDocumentState } from '../utils/documentState';
 
 
@@ -23,6 +43,7 @@ const DocumentEditor = () => {
   const queryClient = useQueryClient();
   const location = useLocation();
   const [drawingFiles, setDrawingFiles] = useState([]);
+  const [modelFile, setModelFile] = useState(null);
   const [selectedDrawingId, setSelectedDrawingId] = useState(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState(null);
@@ -30,8 +51,9 @@ const DocumentEditor = () => {
   const [isGeneratorOpen, setIsGeneratorOpen] = useState(false);
   const isDataLoadedFromServerRef = useRef(false);
 
-  const imageFiles = drawingFiles.filter(f => !f.fileUrl?.toLowerCase().endsWith('.glb'));
-  const selectedImageIndex = imageFiles.findIndex(f => f.fileId === selectedDrawingId);
+  const selectedImageIndex = drawingFiles.findIndex(
+    (f) => f.fileId === selectedDrawingId,
+  );
 
   // --- 데이터 로딩 (React Query) ---
   const { data, isLoading, isError } = useQuery({
@@ -177,14 +199,21 @@ const DocumentEditor = () => {
   };
 
   const handleGenerate3D = async () => {
-    const target = drawingFiles.find(f => f.fileId === selectedDrawingId && !f.fileUrl?.toLowerCase().endsWith('.glb'));
+    if (modelFile) {
+      alert('이미 3D 모델이 존재합니다.');
+      return;
+    }
+    const target = drawingFiles.find((f) => f.fileId === selectedDrawingId);
     if (!target) {
       alert('3D로 변환할 도면을 선택해주세요.');
       return;
     }
     try {
-      const { fileId, fileUrl } = await generate3DModel({ patentId, imageId: target.fileId });
-      setDrawingFiles(prev => [...prev, { fileId, fileUrl, fileName: 'model.glb' }]);
+      const { fileId, fileUrl } = await generate3DModel({
+        patentId,
+        imageId: target.fileId,
+      });
+      setModelFile({ fileId, fileUrl, fileName: 'model.glb' });
       alert('3D 도면 생성이 완료되었습니다.');
     } catch (err) {
       console.error('3D 변환 실패:', err);
@@ -321,9 +350,9 @@ const DocumentEditor = () => {
                 <div ref={el => fieldRefs.current['drawings'] = el} className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
                   <div className="flex items-center justify-between mb-3">
                     <label className="block text-lg font-semibold text-gray-800">도면 업로드</label>
-                    {imageFiles.length > 0 && (
+                    {drawingFiles.length > 0 && (
                       <span className="text-xs text-gray-500">
-                        선택된 도면: {selectedImageIndex >= 0 ? selectedImageIndex + 1 : '-'} / {imageFiles.length}
+                        선택된 도면: {selectedImageIndex >= 0 ? selectedImageIndex + 1 : '-'} / {drawingFiles.length}
                       </span>
                     )}
                   </div>
@@ -332,27 +361,32 @@ const DocumentEditor = () => {
                   {uploadError && <p className="text-sm text-red-500 mt-2">{uploadError}</p>}
                   <div className="grid grid-cols-3 gap-4 mt-4">
                     {drawingFiles.map((f, index) => {
-                      const isGlb = f.fileUrl?.toLowerCase().endsWith('.glb');
                       const isSelected = f.fileId === selectedDrawingId;
                       return (
                         <div
                           key={f.fileId || index}
-                          onClick={() => !isGlb && setSelectedDrawingId(f.fileId)}
-                          className={`relative border rounded-lg overflow-hidden flex items-center justify-center p-2 ${!isGlb ? 'cursor-pointer' : ''} ${isSelected ? 'ring-2 ring-indigo-500' : ''}`}
+                          onClick={() => setSelectedDrawingId(f.fileId)}
+                          className={`relative border rounded-lg overflow-hidden flex items-center justify-center p-2 cursor-pointer ${isSelected ? 'ring-2 ring-indigo-500' : ''}`}
                         >
-                          {isGlb ? (
-                            <a href={f.fileUrl} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">3D 모델 다운로드</a>
-                          ) : (
-                            <>
-                              <img src={f.fileUrl} alt={`도면 미리보기 ${index + 1}`} className="w-full h-auto object-cover" />
-                              {isSelected && (
-                                <span className="absolute top-1 right-1 text-[10px] px-1.5 py-0.5 bg-indigo-600 text-white rounded">선택됨</span>
-                              )}
-                            </>
+                          <img
+                            src={f.fileUrl}
+                            alt={`도면 미리보기 ${index + 1}`}
+                            className="w-full h-auto object-cover"
+                          />
+                          {isSelected && (
+                            <span className="absolute top-1 right-1 text-[10px] px-1.5 py-0.5 bg-indigo-600 text-white rounded">선택됨</span>
                           )}
                         </div>
                       );
                     })}
+                  </div>
+                  <div className="mt-6">
+                    <label className="block text-lg font-semibold text-gray-800 mb-2">3D 모델</label>
+                    {modelFile ? (
+                      <ThreeDModelViewer src={`/api/files/${modelFile.fileId}/content`} />
+                    ) : (
+                      <p className="text-sm text-gray-500">생성된 3D 모델이 없습니다.</p>
+                    )}
                   </div>
                 </div>
               )}

--- a/frontend/applicant_fe/src/pages/PatentDetail.jsx
+++ b/frontend/applicant_fe/src/pages/PatentDetail.jsx
@@ -3,31 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { getPatentDetail } from '../api/patents';
 import { getReviewByPatentId } from '../api/reviews';
 import { getImageUrlsByIds, getNonImageFilesByIds } from '../api/files';
-
-function ModelViewer3D({ src }) {
-  useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
+import ThreeDModelViewer from '../components/ThreeDModelViewer';
 
 const PatentDetail = () => {
   const { id } = useParams();
@@ -64,7 +40,7 @@ const PatentDetail = () => {
                 /\.glb($|\?|#)/i.test(f.name || '') ||
                 /\.glb($|\?|#)/i.test(f.url || '')
             );
-            setGlbUrl(glb ? glb.url : '');
+            setGlbUrl(glb ? `/api/files/${glb.id}/content` : '');
           } catch (err) {
             console.error('첨부 파일 로드 실패:', err);
           }
@@ -166,24 +142,25 @@ const PatentDetail = () => {
             <p className="text-gray-700 whitespace-pre-wrap">{patent.summary || 'N/A'}</p>
           </div>
 
-          {(images.length > 0 || glbUrl) && (
+          {images.length > 0 && (
             <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
               <h2 className="text-lg font-semibold text-gray-800 mb-2">도면</h2>
-              <div className="space-y-4">
-                {images.length > 0 && (
-                  <div className="flex flex-wrap gap-4">
-                    {images.map((src, idx) => (
-                      <img
-                        key={idx}
-                        src={src}
-                        alt={`drawing-${idx}`}
-                        className="max-w-full h-48 object-contain rounded border border-gray-200"
-                      />
-                    ))}
-                  </div>
-                )}
-                {glbUrl && <ModelViewer3D src={glbUrl} />}
+              <div className="flex flex-wrap gap-4">
+                {images.map((src, idx) => (
+                  <img
+                    key={idx}
+                    src={src}
+                    alt={`drawing-${idx}`}
+                    className="max-w-full h-48 object-contain rounded border border-gray-200"
+                  />
+                ))}
               </div>
+            </div>
+          )}
+          {glbUrl && (
+            <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-800 mb-2">3D 모델</h2>
+              <ThreeDModelViewer src={glbUrl} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- load 3D model viewer via `/api/files/{id}/content` to avoid S3 CORS
- reference backend file streaming in patent detail and modal pages

## Testing
- `./gradlew test` *(failed: Could not resolve dependencies, the trustAnchors parameter must be non-empty)*
- `npm test --prefix frontend/applicant_fe` *(missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68ad114c53f08320aa2e059cbb1d7828