### PR TITLE
Use API content path for GLB models

### DIFF
--- a/frontend/examiner_fe/src/pages/DesignReview.jsx
+++ b/frontend/examiner_fe/src/pages/DesignReview.jsx
@@ -378,8 +378,12 @@ export default function DesignReview() {
             ]);
             setAttachmentImageUrls(images);
             setAttachmentOtherFiles(others);
-            const glb = others.find(f => /\.glb($|\?|#)/i.test(f?.name || '') || /\.glb($|\?|#)/i.test(f?.url || ''));
-            setGlbModelUrl(glb ? glb.url : '');
+            const glb = others.find(
+              f =>
+                /\.glb($|\?|#)/i.test(f?.name || '') ||
+                /\.glb($|\?|#)/i.test(f?.url || '')
+            );
+            setGlbModelUrl(glb ? `/api/files/${glb.id}/content` : '');
           } catch {
             setAttachmentImageUrls([]); setAttachmentOtherFiles([]); setGlbModelUrl('');
           }

--- a/frontend/examiner_fe/src/pages/PatentReview.jsx
+++ b/frontend/examiner_fe/src/pages/PatentReview.jsx
@@ -308,8 +308,12 @@ export default function PatentReview() {
             setAttachmentOtherFiles(others);
 
             // 🔎 첨부 비이미지에서 .glb 찾기 → 3D 도면 자동 표시용
-            const glb = others.find(f => /\.glb($|\?|#)/i.test(f?.name || '') || /\.glb($|\?|#)/i.test(f?.url || ''));
-            setGlbModelUrl(glb ? glb.url : '');
+            const glb = others.find(
+              f =>
+                /\.glb($|\?|#)/i.test(f?.name || '') ||
+                /\.glb($|\?|#)/i.test(f?.url || '')
+            );
+            setGlbModelUrl(glb ? `/api/files/${glb.id}/content` : '');
           } catch (e) {
             console.warn('첨부 로드 실패:', e);
             setAttachmentImageUrls([]);


### PR DESCRIPTION
## Summary
- Load GLB attachments in patent review via `/api/files/{id}/content`
- Load GLB attachments in design review via `/api/files/{id}/content`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1ddbb3dc83208fd87a6ece858a20