### PR TITLE
Use backend file endpoint for GLB models

### DIFF
--- a/frontend/applicant_fe/src/api/files.js
+++ b/frontend/applicant_fe/src/api/files.js
@@ -76,16 +76,15 @@ export const getNonImageFilesByIds = async (fileIds = []) => {
   const metas = await fetchMetas(fileIds);
   return metas
     .filter((m) => !isImageName(m.fileName || ''))
-    .map((m) => {
-      const fallback =
-        m.patentId && m.fileName
-          ? `/api/files/${m.patentId}/${encodeURIComponent(m.fileName)}`
-          : '';
-      const url = toAbsoluteFileUrl(m.fileUrl || m.url || fallback);
-      return url
-        ? { id: m.fileId || m.id, name: m.fileName || m.name || '', url }
-        : null;
-    })
+    .map((m) =>
+      m.fileId
+        ? {
+            id: m.fileId,
+            name: m.fileName || m.name || '',
+            url: `/api/files/${m.fileId}/content`,
+          }
+        : null
+    )
     .filter(Boolean);
 };
 

--- a/frontend/examiner_fe/src/api/files.js
+++ b/frontend/examiner_fe/src/api/files.js
@@ -72,16 +72,15 @@ export async function getNonImageFilesByIds(fileIds = []) {
   const metas = await fetchMetas(fileIds);
   return metas
     .filter((m) => !isImageName(m.fileName || ''))
-    .map((m) => {
-      const fallback =
-        m.patentId && m.fileName
-          ? `/api/files/${m.patentId}/${encodeURIComponent(m.fileName)}`
-          : '';
-      const url = toAbsoluteFileUrl(m.fileUrl || m.url || fallback);
-      return url
-        ? { id: m.fileId || m.id, name: m.fileName || m.name || '', url }
-        : null;
-    })
+    .map((m) =>
+      m.fileId
+        ? {
+            id: m.fileId,
+            name: m.fileName || m.name || '',
+            url: `/api/files/${m.fileId}/content`,
+          }
+        : null
+    )
     .filter(Boolean);
 }
 

--- a/frontend/examiner_fe/src/pages/DesignReview.jsx
+++ b/frontend/examiner_fe/src/pages/DesignReview.jsx
@@ -383,6 +383,7 @@ export default function DesignReview() {
                 /\.glb($|\?|#)/i.test(f?.name || '') ||
                 /\.glb($|\?|#)/i.test(f?.url || '')
             );
+            // Use backend endpoint to stream GLB content instead of direct S3 URLs
             setGlbModelUrl(glb ? `/api/files/${glb.id}/content` : '');
           } catch {
             setAttachmentImageUrls([]); setAttachmentOtherFiles([]); setGlbModelUrl('');


### PR DESCRIPTION
## Summary
- Stream GLB attachments through backend endpoint in design review
- Return `/api/files/{id}/content` for non-image attachments in examiner and applicant APIs

## Testing
- `cd frontend/examiner_fe && npm test` *(fails: Missing script "test")*
- `cd frontend/applicant_fe && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad213f08348320bbf6ba57ef06bf7d