### PR TITLE
feat: ensure single GLB attachment

### DIFF
--- a/frontend/applicant_fe/src/pages/DocumentEditor.jsx
+++ b/frontend/applicant_fe/src/pages/DocumentEditor.jsx
@@ -9,7 +9,7 @@ import {
   generateFullDraft,
   generate3DModel,
 } from '../api/patents';
-import { uploadFile } from '../api/files';
+import { uploadFile, getFileDetail } from '../api/files';
 import {
   FileText,
   Save,
@@ -93,6 +93,36 @@ const DocumentEditor = () => {
     isDataLoadedFromServerRef.current = true;
   }
   }, [data, location.state, patentId]);
+
+  useEffect(() => {
+    if (data?.attachmentIds?.length) {
+      (async () => {
+        try {
+          const metas = await Promise.all(
+            data.attachmentIds.map((id) => getFileDetail(id))
+          );
+          const images = metas
+            .filter((m) => m.fileType === 'IMAGE')
+            .map(({ fileId, fileUrl, fileName }) => ({ fileId, fileUrl, fileName }));
+          setDrawingFiles(images);
+          if (images.length > 0) {
+            setSelectedDrawingId(images[0].fileId);
+          }
+          const glbMeta = metas.find((m) => m.fileType === 'GLB');
+          setModelFile(
+            glbMeta
+              ? { fileId: glbMeta.fileId, fileUrl: glbMeta.fileUrl, fileName: glbMeta.fileName }
+              : null
+          );
+        } catch (err) {
+          console.error('첨부 파일 로딩 실패:', err);
+        }
+      })();
+    } else {
+      setDrawingFiles([]);
+      setModelFile(null);
+    }
+  }, [data]);
 
   useEffect(() => {
     isDataLoadedFromServerRef.current = false;
@@ -199,10 +229,6 @@ const DocumentEditor = () => {
   };
 
   const handleGenerate3D = async () => {
-    if (modelFile) {
-      alert('이미 3D 모델이 존재합니다.');
-      return;
-    }
     const target = drawingFiles.find((f) => f.fileId === selectedDrawingId);
     if (!target) {
       alert('3D로 변환할 도면을 선택해주세요.');


### PR DESCRIPTION
## Summary
- load existing attachments and track a single GLB per patent in document editor
- display GLB via backend file content route
- rely on backend file service to replace old GLB when a new one is generated

## Testing
- `npm test` *(fails: Missing script "test")*
- `./gradlew test` *(fails: Could not resolve Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2143383c8320a7386c31478ba680