### PR TITLE
Proxy GLB loading through backend

### DIFF
--- a/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
+++ b/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
@@ -1,6 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const ThreeDModelViewer = ({ src }) => {
+  const [modelUrl, setModelUrl] = useState('');
+
+  // Lazy-load <model-viewer> web component
   useEffect(() => {
     if (!window.customElements || !window.customElements.get('model-viewer')) {
       const script = document.createElement('script');
@@ -10,12 +13,43 @@ const ThreeDModelViewer = ({ src }) => {
     }
   }, []);
 
+  // Fetch GLB with auth token and convert to blob URL
+  useEffect(() => {
+    if (!src) return;
+    let objectUrl;
+    const fetchModel = async () => {
+      try {
+        const token =
+          localStorage.getItem('token') ||
+          localStorage.getItem('accessToken') ||
+          sessionStorage.getItem('token') ||
+          sessionStorage.getItem('accessToken') || '';
+
+        const res = await fetch(src, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('GLB fetch failed');
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setModelUrl(objectUrl);
+      } catch (e) {
+        console.error('3D 모델 로드 실패:', e);
+        setModelUrl('');
+      }
+    };
+    fetchModel();
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
   return (
     <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
       {/* @ts-ignore */}
       <model-viewer
         style={{ width: '100%', height: '100%' }}
-        src={src}
+        src={modelUrl}
         camera-controls
         auto-rotate
         exposure="1.0"

--- a/frontend/applicant_fe/src/pages/DocumentEditor.jsx
+++ b/frontend/applicant_fe/src/pages/DocumentEditor.jsx
@@ -111,7 +111,12 @@ const DocumentEditor = () => {
           const glbMeta = metas.find((m) => m.fileType === 'GLB');
           setModelFile(
             glbMeta
-              ? { fileId: glbMeta.fileId, fileUrl: glbMeta.fileUrl, fileName: glbMeta.fileName }
+              ? {
+                  fileId: glbMeta.fileId,
+                  // Always stream GLB through backend proxy instead of direct S3 URL
+                  fileUrl: `/api/files/${glbMeta.fileId}/content`,
+                  fileName: glbMeta.fileName,
+                }
               : null
           );
         } catch (err) {
@@ -235,11 +240,12 @@ const DocumentEditor = () => {
       return;
     }
     try {
-      const { fileId, fileUrl } = await generate3DModel({
+      const { fileId } = await generate3DModel({
         patentId,
         imageId: target.fileId,
       });
-      setModelFile({ fileId, fileUrl, fileName: 'model.glb' });
+      // Use backend streaming endpoint for the generated GLB
+      setModelFile({ fileId, fileUrl: `/api/files/${fileId}/content`, fileName: 'model.glb' });
       alert('3D 도면 생성이 완료되었습니다.');
     } catch (err) {
       console.error('3D 변환 실패:', err);

--- a/frontend/examiner_fe/src/pages/PatentReview.jsx
+++ b/frontend/examiner_fe/src/pages/PatentReview.jsx
@@ -104,6 +104,8 @@ function SmartImage({ source, className, alt }) {
 
 // 간단한 3D 뷰어: model-viewer 사용
 function ModelViewer3D({ src }) {
+  const [modelUrl, setModelUrl] = useState('');
+
   React.useEffect(() => {
     if (!window.customElements || !window.customElements.get('model-viewer')) {
       const script = document.createElement('script');
@@ -112,12 +114,43 @@ function ModelViewer3D({ src }) {
       document.head.appendChild(script);
     }
   }, []);
+
+  React.useEffect(() => {
+    if (!src) return;
+    let objectUrl;
+    const load = async () => {
+      try {
+        const token =
+          localStorage.getItem('token') ||
+          localStorage.getItem('accessToken') ||
+          sessionStorage.getItem('token') ||
+          sessionStorage.getItem('accessToken') || '';
+
+        const res = await fetch(src, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('GLB fetch failed');
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setModelUrl(objectUrl);
+      } catch (e) {
+        console.error('3D 모델 로드 실패:', e);
+        setModelUrl('');
+      }
+    };
+    load();
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
   return (
     <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
       {/* @ts-ignore */}
       <model-viewer
         style={{ width: '100%', height: '100%' }}
-        src={src}
+        src={modelUrl}
         camera-controls
         auto-rotate
         exposure="1.0"


### PR DESCRIPTION
## Summary
- Stream 3D models through `/api/files/{id}/content` using authenticated fetches so protected GLB files load in applicant and examiner views

## Testing
- `npm run lint` (frontend/applicant_fe)
- `npm run lint` (frontend/examiner_fe` *fails: existing lint errors*)

------
https://chatgpt.com/codex/tasks/task_e_68ad22e96b3883209eeb7eeabfbdd571