### PR TITLE
refactor: load glb through backend in viewers

### DIFF
--- a/frontend/applicant_fe/src/pages/DocumentEditor.jsx
+++ b/frontend/applicant_fe/src/pages/DocumentEditor.jsx
@@ -111,7 +111,12 @@ const DocumentEditor = () => {
           const glbMeta = metas.find((m) => m.fileType === 'GLB');
           setModelFile(
             glbMeta
-              ? { fileId: glbMeta.fileId, fileUrl: glbMeta.fileUrl, fileName: glbMeta.fileName }
+              ? {
+                  fileId: glbMeta.fileId,
+                  // Always stream GLB through backend proxy instead of direct S3 URL
+                  fileUrl: `/api/files/${glbMeta.fileId}/content`,
+                  fileName: glbMeta.fileName,
+                }
               : null
           );
         } catch (err) {
@@ -235,11 +240,12 @@ const DocumentEditor = () => {
       return;
     }
     try {
-      const { fileId, fileUrl } = await generate3DModel({
+      const { fileId } = await generate3DModel({
         patentId,
         imageId: target.fileId,
       });
-      setModelFile({ fileId, fileUrl, fileName: 'model.glb' });
+      // Use backend streaming endpoint for the generated GLB
+      setModelFile({ fileId, fileUrl: `/api/files/${fileId}/content`, fileName: 'model.glb' });
       alert('3D 도면 생성이 완료되었습니다.');
     } catch (err) {
       console.error('3D 변환 실패:', err);

--- a/frontend/examiner_fe/src/components/ThreeDModelViewer.jsx
+++ b/frontend/examiner_fe/src/components/ThreeDModelViewer.jsx
@@ -1,40 +1,67 @@
-import React, { Suspense } from 'react';
-import { Canvas } from '@react-three/fiber';
-import { useGLTF, OrbitControls, Environment } from '@react-three/drei';
+import React, { useEffect, useState } from 'react';
 
-// GLB 모델을 로드하고 렌더링하는 컴포넌트
-function Model({ modelPath }) {
-  const { scene } = useGLTF(modelPath);
-  return <primitive object={scene} scale={2.80} />; // 모델 크기 조절 (필요에 따라 조절)
-}
+/**
+ * Authenticated GLB viewer for examiner pages.
+ * Always fetches the model through the backend so protected files load correctly.
+ */
+export default function ThreeDModelViewer({ src }) {
+  const [modelUrl, setModelUrl] = useState('');
 
-export default function ThreeDModelViewer({ glbPath }) {
+  // Lazy load <model-viewer>
+  useEffect(() => {
+    if (!window.customElements || !window.customElements.get('model-viewer')) {
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
+      document.head.appendChild(script);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!src) return;
+    let objectUrl;
+    const load = async () => {
+      try {
+        const token =
+          localStorage.getItem('token') ||
+          localStorage.getItem('accessToken') ||
+          sessionStorage.getItem('token') ||
+          sessionStorage.getItem('accessToken') || '';
+        const res = await fetch(src, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('GLB fetch failed');
+        const ct = res.headers.get('content-type') || '';
+        if (!/model\/gltf-binary|application\/octet-stream/.test(ct)) {
+          throw new Error(`Unexpected content-type: ${ct}`);
+        }
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setModelUrl(objectUrl);
+      } catch (e) {
+        console.error('3D 모델 로드 실패:', e);
+        setModelUrl('');
+      }
+    };
+    load();
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
   return (
-    <div className="w-full h-[400px] bg-gray-100 rounded-lg overflow-hidden relative border border-gray-200">
-      <Canvas camera={{ position: [0, 0, 5], fov: 75 }}>
-        {/* AmbientLight: 전반적인 빛 */}
-        <ambientLight intensity={0.5} />
-        {/* DirectionalLight: 특정 방향에서 오는 빛 (그림자 생성 가능) */}
-        <directionalLight position={[2, 2, 2]} intensity={1} />
-        
-        {/* Suspense: 모델 로딩 중 폴백 UI 표시 */}
-        <Suspense fallback={<Html center><p className="text-gray-600 text-lg">3D 모델 로딩 중...</p></Html>}>
-          <Model modelPath={glbPath} />
-        </Suspense>
-        
-        {/* OrbitControls: 마우스로 모델을 회전, 확대/축소 가능하게 함 */}
-        <OrbitControls enableZoom enablePan enableRotate />
-        
-        {/* Environment: 주변 환경 맵 (선택 사항, 모델의 재질에 따라 반사 효과 추가) */}
-        {/* <Environment preset="sunset" background /> */} {/* 'sunset', 'dawn', 'warehouse' 등 다양한 프리셋 */}
-      </Canvas>
-      <p className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs text-gray-500 bg-white bg-opacity-75 px-2 py-1 rounded">
-        마우스로 드래그하여 3D 모델을 회전, 확대/축소하세요.
-      </p>
+    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
+      {/* @ts-ignore */}
+      <model-viewer
+        style={{ width: '100%', height: '100%' }}
+        src={modelUrl}
+        camera-controls
+        auto-rotate
+        exposure="1.0"
+        shadow-intensity="1"
+        ar
+      />
     </div>
   );
 }
-
-// Html 컴포넌트는 @react-three/drei 에서 임포트합니다. 
-// Suspense fallback에 HTML 요소를 렌더링하기 위함
-import { Html } from '@react-three/drei';

--- a/frontend/examiner_fe/src/pages/DesignReview.jsx
+++ b/frontend/examiner_fe/src/pages/DesignReview.jsx
@@ -18,6 +18,7 @@ import {
 
 // 파일 API
 import { getImageUrlsByIds, getNonImageFilesByIds, toAbsoluteFileUrl } from '../api/files';
+import ThreeDModelViewer from '../components/ThreeDModelViewer';
 
 /* ------------------------- 유틸 & 보조 컴포넌트 ------------------------- */
 
@@ -126,31 +127,6 @@ function cleanFileName(name = '') {
   return decoded.replace(/^[0-9a-fA-F-]{36}_/, '');
 }
 
-// 3D 뷰어
-function ModelViewer3D({ src }) {
-  useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
 
 // 로그인 유저 ID
 const getCurrentUserId = () => {
@@ -1062,7 +1038,7 @@ ${new Date().getFullYear()}년 ${new Date().getMonth() + 1}월 ${new Date().getD
                   </h4>
                 </div>
                 {glbModelUrl ? (
-                  <ModelViewer3D src={glbModelUrl} />
+                  <ThreeDModelViewer src={glbModelUrl} />
                 ) : (
                   <div className="w-full h-24 bg-gray-50 border border-dashed border-gray-300 rounded-lg flex items-center justify-center text-sm text-gray-500">
                     첨부 파일에서 .glb 파일을 찾지 못했습니다. .glb 파일을 업로드하면 자동으로 표시됩니다.

--- a/frontend/examiner_fe/src/pages/PatentReview.jsx
+++ b/frontend/examiner_fe/src/pages/PatentReview.jsx
@@ -20,6 +20,7 @@ import {
 
 // 파일 API (메타 조회 → 안전한 URL 만들기)
 import { getImageUrlsByIds, getNonImageFilesByIds, toAbsoluteFileUrl } from '../api/files';
+import ThreeDModelViewer from '../components/ThreeDModelViewer';
 
 /* ------------------------- 보조 ------------------------- */
 
@@ -102,31 +103,6 @@ function SmartImage({ source, className, alt }) {
   return <img alt={alt} src={resolvedSrc} className={className} onError={handleError} />;
 }
 
-// 간단한 3D 뷰어: model-viewer 사용
-function ModelViewer3D({ src }) {
-  React.useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
 
 // 도면 URL 파서 (JSON 배열/콤마/개행/단일 URL)
 function extractDrawingUrls(raw) {
@@ -950,7 +926,7 @@ ${new Date().getFullYear()}년 ${new Date().getMonth() + 1}월 ${new Date().getD
                   </h4>
                 </div>
                 {glbModelUrl ? (
-                  <ModelViewer3D src={glbModelUrl} />
+                  <ThreeDModelViewer src={glbModelUrl} />
                 ) : (
                   <div className="w-full h-24 bg-gray-50 border border-dashed border-gray-300 rounded-lg flex items-center justify-center text-sm text-gray-500">
                     첨부 파일에서 .glb 파일을 찾지 못했습니다. .glb 파일을 업로드하면 자동으로 표시됩니다.


### PR DESCRIPTION
## Summary
- unify 3D model viewers to fetch GLB files through `/api/files/{id}/content`
- add content-type checks to avoid parsing HTML responses
- reuse shared viewer in design and patent review pages

## Testing
- `npm run lint` (frontend/applicant_fe) *(fails: Cannot find package 'globals')*
- `npm run lint` (frontend/examiner_fe) *(fails: 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad22e96b3883209eeb7eeabfbdd571