### PR TITLE
fix: proxy GLB loads through backend

### DIFF
--- a/frontend/applicant_fe/src/api/files.js
+++ b/frontend/applicant_fe/src/api/files.js
@@ -81,7 +81,7 @@ export const getNonImageFilesByIds = async (fileIds = []) => {
         ? {
             id: m.fileId,
             name: m.fileName || m.name || '',
-            url: `/api/files/${m.fileId}/content`,
+            url: toAbsoluteFileUrl(`/api/files/${m.fileId}/content`),
           }
         : null
     )

--- a/frontend/applicant_fe/src/components/PatentDetailModal.jsx
+++ b/frontend/applicant_fe/src/components/PatentDetailModal.jsx
@@ -23,7 +23,7 @@ const PatentDetailModal = ({ patent, onClose }) => {
               /\.glb($|\?|#)/i.test(f.name || '') ||
               /\.glb($|\?|#)/i.test(f.url || '')
           );
-          setGlbUrl(glb ? `/api/files/${glb.id}/content` : '');
+          setGlbUrl(glb ? glb.url : '');
         } catch (err) {
           console.error('첨부 파일 로드 실패:', err);
         }

--- a/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
+++ b/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
@@ -1,6 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 const ThreeDModelViewer = ({ src }) => {
+  const [modelUrl, setModelUrl] = useState('');
+
+  // Lazy-load <model-viewer> web component
   useEffect(() => {
     if (!window.customElements || !window.customElements.get('model-viewer')) {
       const script = document.createElement('script');
@@ -10,12 +13,49 @@ const ThreeDModelViewer = ({ src }) => {
     }
   }, []);
 
+  // Fetch GLB with auth token and convert to blob URL
+  useEffect(() => {
+    if (!src) return;
+    let objectUrl;
+    const fetchModel = async () => {
+      try {
+        const token =
+          localStorage.getItem('token') ||
+          localStorage.getItem('accessToken') ||
+          sessionStorage.getItem('token') ||
+          sessionStorage.getItem('accessToken') || '';
+
+        const apiBase = import.meta.env.VITE_SPRING_API_URL || 'http://35.175.253.22:8080';
+        const target = src.startsWith('http') ? src : `${apiBase}${src}`;
+        const res = await fetch(target, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('GLB fetch failed');
+        const ct = res.headers.get('content-type') || '';
+        if (!/model\/gltf-binary|application\/octet-stream/.test(ct)) {
+          throw new Error(`Unexpected content-type: ${ct}`);
+        }
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setModelUrl(objectUrl);
+      } catch (e) {
+        console.error('3D 모델 로드 실패:', e);
+        setModelUrl('');
+      }
+    };
+    fetchModel();
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
   return (
     <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
       {/* @ts-ignore */}
       <model-viewer
         style={{ width: '100%', height: '100%' }}
-        src={src}
+        src={modelUrl}
         camera-controls
         auto-rotate
         exposure="1.0"

--- a/frontend/applicant_fe/src/pages/PatentDetail.jsx
+++ b/frontend/applicant_fe/src/pages/PatentDetail.jsx
@@ -41,7 +41,7 @@ const PatentDetail = () => {
                 /\.glb($|\?|#)/i.test(f.url || '')
             );
             // Use backend file-serving route instead of direct S3 URL
-            setGlbUrl(glb ? `/api/files/${glb.id}/content` : '');
+            setGlbUrl(glb ? glb.url : '');
           } catch (err) {
             console.error('첨부 파일 로드 실패:', err);
           }

--- a/frontend/examiner_fe/src/api/files.js
+++ b/frontend/examiner_fe/src/api/files.js
@@ -53,16 +53,7 @@ export async function getImageUrlsByIds(fileIds = []) {
   const metas = await fetchMetas(fileIds);
   return metas
     .filter((m) => isImageName(m.fileName || ''))
-    // .map((m) => {
-    //   const primary = m.fileUrl || m.url || '';
-    //   if (primary) return toAbsoluteFileUrl(primary);
-    //   if (m.patentId && m.fileName) {
-    //     const enc = encodeURIComponent(m.fileName);
-    //     return toAbsoluteFileUrl(`/api/files/${m.patentId}/${enc}`);
-    //   }
-    //   return '';
-    // })
-    .map((m) => `/api/files/${m.fileId}/content`)
+    .map((m) => toAbsoluteFileUrl(`/api/files/${m.fileId}/content`))
     .filter(Boolean);
 }
 
@@ -77,7 +68,7 @@ export async function getNonImageFilesByIds(fileIds = []) {
         ? {
             id: m.fileId,
             name: m.fileName || m.name || '',
-            url: `/api/files/${m.fileId}/content`,
+            url: toAbsoluteFileUrl(`/api/files/${m.fileId}/content`),
           }
         : null
     )

--- a/frontend/examiner_fe/src/components/ThreeDModelViewer.jsx
+++ b/frontend/examiner_fe/src/components/ThreeDModelViewer.jsx
@@ -1,40 +1,69 @@
-import React, { Suspense } from 'react';
-import { Canvas } from '@react-three/fiber';
-import { useGLTF, OrbitControls, Environment } from '@react-three/drei';
+import React, { useEffect, useState } from 'react';
 
-// GLB 모델을 로드하고 렌더링하는 컴포넌트
-function Model({ modelPath }) {
-  const { scene } = useGLTF(modelPath);
-  return <primitive object={scene} scale={2.80} />; // 모델 크기 조절 (필요에 따라 조절)
-}
+/**
+ * Authenticated GLB viewer for examiner pages.
+ * Always fetches the model through the backend so protected files load correctly.
+ */
+export default function ThreeDModelViewer({ src }) {
+  const [modelUrl, setModelUrl] = useState('');
 
-export default function ThreeDModelViewer({ glbPath }) {
+  // Lazy load <model-viewer>
+  useEffect(() => {
+    if (!window.customElements || !window.customElements.get('model-viewer')) {
+      const script = document.createElement('script');
+      script.type = 'module';
+      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
+      document.head.appendChild(script);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!src) return;
+    let objectUrl;
+    const load = async () => {
+      try {
+        const token =
+          localStorage.getItem('token') ||
+          localStorage.getItem('accessToken') ||
+          sessionStorage.getItem('token') ||
+          sessionStorage.getItem('accessToken') || '';
+        const apiBase = import.meta.env.VITE_SPRING_API_URL || 'http://35.175.253.22:8080';
+        const target = src.startsWith('http') ? src : `${apiBase}${src}`;
+        const res = await fetch(target, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+          credentials: 'include',
+        });
+        if (!res.ok) throw new Error('GLB fetch failed');
+        const ct = res.headers.get('content-type') || '';
+        if (!/model\/gltf-binary|application\/octet-stream/.test(ct)) {
+          throw new Error(`Unexpected content-type: ${ct}`);
+        }
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setModelUrl(objectUrl);
+      } catch (e) {
+        console.error('3D 모델 로드 실패:', e);
+        setModelUrl('');
+      }
+    };
+    load();
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [src]);
+
   return (
-    <div className="w-full h-[400px] bg-gray-100 rounded-lg overflow-hidden relative border border-gray-200">
-      <Canvas camera={{ position: [0, 0, 5], fov: 75 }}>
-        {/* AmbientLight: 전반적인 빛 */}
-        <ambientLight intensity={0.5} />
-        {/* DirectionalLight: 특정 방향에서 오는 빛 (그림자 생성 가능) */}
-        <directionalLight position={[2, 2, 2]} intensity={1} />
-        
-        {/* Suspense: 모델 로딩 중 폴백 UI 표시 */}
-        <Suspense fallback={<Html center><p className="text-gray-600 text-lg">3D 모델 로딩 중...</p></Html>}>
-          <Model modelPath={glbPath} />
-        </Suspense>
-        
-        {/* OrbitControls: 마우스로 모델을 회전, 확대/축소 가능하게 함 */}
-        <OrbitControls enableZoom enablePan enableRotate />
-        
-        {/* Environment: 주변 환경 맵 (선택 사항, 모델의 재질에 따라 반사 효과 추가) */}
-        {/* <Environment preset="sunset" background /> */} {/* 'sunset', 'dawn', 'warehouse' 등 다양한 프리셋 */}
-      </Canvas>
-      <p className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs text-gray-500 bg-white bg-opacity-75 px-2 py-1 rounded">
-        마우스로 드래그하여 3D 모델을 회전, 확대/축소하세요.
-      </p>
+    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
+      {/* @ts-ignore */}
+      <model-viewer
+        style={{ width: '100%', height: '100%' }}
+        src={modelUrl}
+        camera-controls
+        auto-rotate
+        exposure="1.0"
+        shadow-intensity="1"
+        ar
+      />
     </div>
   );
 }
-
-// Html 컴포넌트는 @react-three/drei 에서 임포트합니다. 
-// Suspense fallback에 HTML 요소를 렌더링하기 위함
-import { Html } from '@react-three/drei';

--- a/frontend/examiner_fe/src/pages/DesignReview.jsx
+++ b/frontend/examiner_fe/src/pages/DesignReview.jsx
@@ -18,6 +18,7 @@ import {
 
 // 파일 API
 import { getImageUrlsByIds, getNonImageFilesByIds, toAbsoluteFileUrl } from '../api/files';
+import ThreeDModelViewer from '../components/ThreeDModelViewer';
 
 /* ------------------------- 유틸 & 보조 컴포넌트 ------------------------- */
 
@@ -126,31 +127,6 @@ function cleanFileName(name = '') {
   return decoded.replace(/^[0-9a-fA-F-]{36}_/, '');
 }
 
-// 3D 뷰어
-function ModelViewer3D({ src }) {
-  useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
 
 // 로그인 유저 ID
 const getCurrentUserId = () => {
@@ -384,7 +360,7 @@ export default function DesignReview() {
                 /\.glb($|\?|#)/i.test(f?.url || '')
             );
             // Use backend endpoint to stream GLB content instead of direct S3 URLs
-            setGlbModelUrl(glb ? `/api/files/${glb.id}/content` : '');
+            setGlbModelUrl(glb ? glb.url : '');
           } catch {
             setAttachmentImageUrls([]); setAttachmentOtherFiles([]); setGlbModelUrl('');
           }
@@ -1062,7 +1038,7 @@ ${new Date().getFullYear()}년 ${new Date().getMonth() + 1}월 ${new Date().getD
                   </h4>
                 </div>
                 {glbModelUrl ? (
-                  <ModelViewer3D src={glbModelUrl} />
+                  <ThreeDModelViewer src={glbModelUrl} />
                 ) : (
                   <div className="w-full h-24 bg-gray-50 border border-dashed border-gray-300 rounded-lg flex items-center justify-center text-sm text-gray-500">
                     첨부 파일에서 .glb 파일을 찾지 못했습니다. .glb 파일을 업로드하면 자동으로 표시됩니다.

--- a/frontend/examiner_fe/src/pages/PatentReview.jsx
+++ b/frontend/examiner_fe/src/pages/PatentReview.jsx
@@ -20,6 +20,7 @@ import {
 
 // 파일 API (메타 조회 → 안전한 URL 만들기)
 import { getImageUrlsByIds, getNonImageFilesByIds, toAbsoluteFileUrl } from '../api/files';
+import ThreeDModelViewer from '../components/ThreeDModelViewer';
 
 /* ------------------------- 보조 ------------------------- */
 
@@ -102,31 +103,6 @@ function SmartImage({ source, className, alt }) {
   return <img alt={alt} src={resolvedSrc} className={className} onError={handleError} />;
 }
 
-// 간단한 3D 뷰어: model-viewer 사용
-function ModelViewer3D({ src }) {
-  React.useEffect(() => {
-    if (!window.customElements || !window.customElements.get('model-viewer')) {
-      const script = document.createElement('script');
-      script.type = 'module';
-      script.src = 'https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js';
-      document.head.appendChild(script);
-    }
-  }, []);
-  return (
-    <div className="w-full h-72 bg-gray-100 rounded-lg overflow-hidden border border-gray-200 flex items-center justify-center">
-      {/* @ts-ignore */}
-      <model-viewer
-        style={{ width: '100%', height: '100%' }}
-        src={src}
-        camera-controls
-        auto-rotate
-        exposure="1.0"
-        shadow-intensity="1"
-        ar
-      />
-    </div>
-  );
-}
 
 // 도면 URL 파서 (JSON 배열/콤마/개행/단일 URL)
 function extractDrawingUrls(raw) {
@@ -313,7 +289,7 @@ export default function PatentReview() {
                 /\.glb($|\?|#)/i.test(f?.name || '') ||
                 /\.glb($|\?|#)/i.test(f?.url || '')
             );
-            setGlbModelUrl(glb ? `/api/files/${glb.id}/content` : '');
+            setGlbModelUrl(glb ? glb.url : '');
           } catch (e) {
             console.warn('첨부 로드 실패:', e);
             setAttachmentImageUrls([]);
@@ -950,7 +926,7 @@ ${new Date().getFullYear()}년 ${new Date().getMonth() + 1}월 ${new Date().getD
                   </h4>
                 </div>
                 {glbModelUrl ? (
-                  <ModelViewer3D src={glbModelUrl} />
+                  <ThreeDModelViewer src={glbModelUrl} />
                 ) : (
                   <div className="w-full h-24 bg-gray-50 border border-dashed border-gray-300 rounded-lg flex items-center justify-center text-sm text-gray-500">
                     첨부 파일에서 .glb 파일을 찾지 못했습니다. .glb 파일을 업로드하면 자동으로 표시됩니다.


### PR DESCRIPTION
## Summary
- ensure GLB viewers fetch through backend host
- convert file helper URLs to absolute API paths
- wire 3D model links across screens to backend proxy

## Testing
- `npm run lint` (frontend/applicant_fe) *(fails: Cannot find package 'globals')*
- `npm run lint` (frontend/examiner_fe) *(fails: 11 errors)*
- `npm test` (frontend/examiner_fe) *(fails: Missing script "test")*
- `npm test` (frontend/applicant_fe) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad22e96b3883209eeb7eeabfbdd571