### PR TITLE
Use message field for chat session API

### DIFF
--- a/frontend/applicant_fe/src/api/patents.js
+++ b/frontend/applicant_fe/src/api/patents.js
@@ -204,7 +204,7 @@ export const startChatSession = async (patentId) => {
 // [추가] 챗봇 메시지 전송 API
 export const sendMessageToSession = async ({ sessionId, content }) => {
   try {
-    const res = await axios.post(`/api/ai/chat/sessions/${sessionId}/messages`, { content });
+    const res = await axios.post(`/api/ai/chat/sessions/${sessionId}/messages`, { message: content });
     return res.data; // { sender: "ai", content: "..." } 를 반환
   } catch (error) {
     console.error('챗봇 메시지 전송 실패:', error);


### PR DESCRIPTION
## Summary
- send `message` field when posting to chat session messages API

## Testing
- `npm run lint` *(fails: S3_PUBLIC_BASE is not defined, unused vars in several files)*
- `curl -s -X POST http://3.26.101.212:8000/api/ai/chat/sessions -H 'Content-Type: application/json' -d '{"patentId":1}'` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad46b87110832094a42699e587f01d