### PR TITLE
Align GLB viewer exposure

### DIFF
--- a/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
+++ b/frontend/applicant_fe/src/components/ThreeDModelViewer.jsx
@@ -31,7 +31,7 @@ const ThreeDModelViewer = ({ src }) => {
         src={src}
         camera-controls
         auto-rotate
-        exposure="1.0" // 노출 값을 조금 높여 더 밝게 보이도록 조정했습니다.
+        exposure="0.4"
         shadow-intensity="1"
         ar
       />


### PR DESCRIPTION
## Summary
- set applicant-side `model-viewer` exposure to 0.4 to match other viewers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Irregular whitespace across project)


------
https://chatgpt.com/codex/tasks/task_e_68ae72c5548c83208ff050eafafed5a7